### PR TITLE
Heal wedged checkouts in git_clone too

### DIFF
--- a/src/channel/github/review_checkout.rs
+++ b/src/channel/github/review_checkout.rs
@@ -67,7 +67,9 @@ async fn prepare_at(
     // Reviewing a repo the bot has never worked on clones it. Fetch
     // into the clone, not the worktree: they share refs, and the
     // worktree may not exist yet.
-    let clone = checkout::ensure_cloned(git, url, clone_rel).await?;
+    let clone = checkout::ensure_cloned(git, url, clone_rel)
+        .await?
+        .into_dir();
     let pull_ref = format!("pull/{pr_number}/head");
     checkout::run(git, &["fetch", "origin", base, &pull_ref], &clone, true).await?;
 

--- a/src/channel/linear/execution_checkout.rs
+++ b/src/channel/linear/execution_checkout.rs
@@ -33,7 +33,7 @@ const KEPT_CACHES: &[&str] = &[".direnv", "node_modules", "target", ".venv"];
 
 /// URL-parametrized body of [`prepare`], so tests can use `file://`.
 async fn prepare_at(git: &GitCli, url: &str, rel: &str) -> Result<(), ToolError> {
-    let dir = checkout::ensure_cloned(git, url, rel).await?;
+    let dir = checkout::ensure_cloned(git, url, rel).await?.into_dir();
     checkout::run(git, &["fetch", "origin"], &dir, true).await?;
     checkout::run(
         git,

--- a/src/tools/git/checkout.rs
+++ b/src/tools/git/checkout.rs
@@ -24,13 +24,32 @@ pub(crate) fn rel_path(root: &str, nwo: &str) -> Result<String, ToolError> {
     ))
 }
 
+/// How [`ensure_cloned`] satisfied the request. Callers that treat a
+/// fresh clone differently from a reused checkout (`git_clone` fetches
+/// the latter) branch on this instead of re-deriving it from disk.
+pub(crate) enum Ensured {
+    /// A clone ran: the directory was missing, or held a corrupt
+    /// skeleton that was replaced.
+    Cloned(PathBuf),
+    /// A healthy checkout already existed and was left untouched.
+    Existing(PathBuf),
+}
+
+impl Ensured {
+    pub(crate) fn into_dir(self) -> PathBuf {
+        match self {
+            Self::Cloned(dir) | Self::Existing(dir) => dir,
+        }
+    }
+}
+
 /// Clone `url` into the workspace-relative `rel` unless a healthy
-/// checkout already exists. Returns the absolute checkout directory.
+/// checkout already exists.
 pub(crate) async fn ensure_cloned(
     git: &GitCli,
     url: &str,
     rel: &str,
-) -> Result<PathBuf, ToolError> {
+) -> Result<Ensured, ToolError> {
     let dir = git.workspace_root().join(rel);
     if dir.join(".git").is_dir() {
         // rev-parse is local-only: it fails only when the repo is
@@ -39,7 +58,7 @@ pub(crate) async fn ensure_cloned(
             .await
             .is_ok()
         {
-            return Ok(dir);
+            return Ok(Ensured::Existing(dir));
         }
         // A clone interrupted by machine death leaves a .git skeleton
         // git rejects; trusting is_dir() would wedge this repo forever.
@@ -57,7 +76,7 @@ pub(crate) async fn ensure_cloned(
         let _ = tokio::fs::remove_dir_all(&dir).await;
         return Err(e);
     }
-    Ok(dir)
+    Ok(Ensured::Cloned(dir))
 }
 
 /// Run git in `cwd`, failing on nonzero exit, with optional credential
@@ -149,12 +168,21 @@ mod tests {
         std::fs::create_dir_all(&wedged).unwrap();
 
         let url = format!("file://{}", origin.path().display());
-        let cloned = ensure_cloned(&git, &url, "projects/o/r").await.unwrap();
+        let ensured = ensure_cloned(&git, &url, "projects/o/r").await.unwrap();
 
         assert!(
-            run(&git, &["rev-parse", "--git-dir"], &cloned, false)
-                .await
-                .is_ok(),
+            matches!(ensured, Ensured::Cloned(_)),
+            "a rejected skeleton must be reported as a fresh clone"
+        );
+        assert!(
+            run(
+                &git,
+                &["rev-parse", "--git-dir"],
+                ensured.into_dir().as_path(),
+                false
+            )
+            .await
+            .is_ok(),
             "the skeleton must be replaced by a healthy clone"
         );
     }
@@ -173,10 +201,11 @@ mod tests {
         std::fs::write(checkout.join("work.txt"), "uncommitted").unwrap();
 
         // Unreachable URL: proves no clone is attempted.
-        ensure_cloned(&git, "file:///nowhere-at-all", "projects/o/r")
+        let ensured = ensure_cloned(&git, "file:///nowhere-at-all", "projects/o/r")
             .await
             .unwrap();
 
+        assert!(matches!(ensured, Ensured::Existing(_)));
         assert_eq!(
             std::fs::read_to_string(checkout.join("work.txt")).unwrap(),
             "uncommitted",

--- a/src/tools/git/git_cli.rs
+++ b/src/tools/git/git_cli.rs
@@ -127,7 +127,7 @@ impl GitCli {
         };
         let url = format!("https://github.com/{nwo}.git");
         let dir = match super::checkout::ensure_cloned(self, &url, &rel).await {
-            Ok(dir) => dir,
+            Ok(ensured) => ensured.into_dir(),
             Err(e) => return format!("clone failed: {e}"),
         };
         match self.provision_devshell(&dir).await {

--- a/src/tools/git/git_clone.rs
+++ b/src/tools/git/git_clone.rs
@@ -66,14 +66,14 @@ impl GitClone {
         let (https_url, nwo, rel) = target(url)?;
         let dir = self.git.workspace_root().join(&rel);
 
-        let mut output = if dir.join(".git").is_dir() {
-            // Existing checkout: refresh remote refs only. The working
-            // tree may hold in-progress work; never reposition or clean.
-            checkout::run(&self.git, &["fetch", "origin"], &dir, true).await?;
-            format!("{rel} already cloned; fetched origin")
-        } else {
-            checkout::ensure_cloned(&self.git, &https_url, &rel).await?;
-            format!("Cloned to {rel}")
+        let mut output = match checkout::ensure_cloned(&self.git, &https_url, &rel).await? {
+            checkout::Ensured::Cloned(_) => format!("Cloned to {rel}"),
+            checkout::Ensured::Existing(existing) => {
+                // Refresh remote refs only. The working tree may hold
+                // in-progress work; never reposition or clean.
+                checkout::run(&self.git, &["fetch", "origin"], &existing, true).await?;
+                format!("{rel} already cloned; fetched origin")
+            }
         };
         let _ = write!(output, " (use working_dir: \"{rel}\" with exec)");
 


### PR DESCRIPTION
ensure_cloned recently learned to detect and replace a corrupt .git skeleton (the wedged-clone incident from the warm duty's first live run), but the git_clone tool never benefited: its existing-checkout branch trusts is_dir(".git") and goes straight to fetch. A wedged checkout in the interactive path fails that fetch loudly but never heals.

This routes git_clone through ensure_cloned unconditionally. ensure_cloned returns an Ensured enum saying whether a clone ran or a healthy checkout was reused, so the tool keeps its two honest messages and fetches only in the reuse case, where the working tree may hold in-progress work and must never be repositioned or cleaned. A wedged skeleton is replaced and reported as a fresh clone, because that is what it is.