### PR TITLE
Wire telegram.poll_timeout_secs to getUpdates timeout

### DIFF
--- a/specs/10-channels.md
+++ b/specs/10-channels.md
@@ -281,9 +281,3 @@ forever.
 - No message queuing — the actor processes one envelope at a time
 - No typing indicators — the agent appears offline until the response is ready
   (activity events provide partial progress when verbose is on)
-
-## Open Questions
-
-- `telegram.poll_timeout_secs` is not wired to the `getUpdates` timeout
-  parameter (hardcoded to 30). The config field only affects the HTTP client
-  timeout. Should it be connected or removed?

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -29,11 +29,16 @@ const SEND_RETRIES: u32 = 3;
 pub struct TelegramChannel {
     client: TelegramClient,
     chat_id: i64,
+    poll_timeout_secs: u64,
 }
 
 impl TelegramChannel {
-    pub fn new(client: TelegramClient, chat_id: i64) -> Self {
-        Self { client, chat_id }
+    pub fn new(client: TelegramClient, chat_id: i64, poll_timeout_secs: u64) -> Self {
+        Self {
+            client,
+            chat_id,
+            poll_timeout_secs,
+        }
     }
 
     pub fn chat_id(&self) -> i64 {
@@ -119,7 +124,11 @@ pub async fn poll_loop(channel: &TelegramChannel, handle: &AgentHandle) -> ! {
     let mut verbose = false;
 
     loop {
-        let updates = match channel.client.poll_updates(offset, 30).await {
+        let updates = match channel
+            .client
+            .poll_updates(offset, channel.poll_timeout_secs)
+            .await
+        {
             Ok(updates) => updates,
             Err(TelegramError::Network(ref e)) => {
                 error!("Telegram poll error: {e}");
@@ -259,6 +268,7 @@ mod tests {
         send_results: Vec<Result<(), TelegramError>>,
         send_index: AtomicUsize,
         sent: Mutex<Vec<SentMessage>>,
+        last_poll_timeout: Mutex<Option<u64>>,
     }
 
     impl FakeTelegram {
@@ -268,6 +278,7 @@ mod tests {
                 send_results,
                 send_index: AtomicUsize::new(0),
                 sent: Mutex::new(Vec::new()),
+                last_poll_timeout: Mutex::new(None),
             })
         }
 
@@ -278,6 +289,10 @@ mod tests {
 
         fn sent_messages(&self) -> Vec<SentMessage> {
             self.sent.lock().unwrap().clone()
+        }
+
+        fn last_poll_timeout(&self) -> Option<u64> {
+            *self.last_poll_timeout.lock().unwrap()
         }
 
         fn ok_json(result: &impl serde::Serialize) -> Vec<u8> {
@@ -308,6 +323,8 @@ mod tests {
             async move {
                 match method.as_str() {
                     "getUpdates" => {
+                        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                        *state.last_poll_timeout.lock().unwrap() = body["timeout"].as_u64();
                         let next = state.poll_results.lock().unwrap().pop_front();
                         match next {
                             Some(updates) => Ok(RawResponse {
@@ -368,7 +385,7 @@ mod tests {
     const CHAT_ID: i64 = 42;
 
     fn channel(state: &Arc<FakeTelegram>) -> TelegramChannel {
-        TelegramChannel::new(fake_client(state), CHAT_ID)
+        TelegramChannel::new(fake_client(state), CHAT_ID, 30)
     }
 
     fn spawn_handle(
@@ -617,5 +634,24 @@ mod tests {
         let _ = tokio::time::timeout(Duration::from_millis(100), poll_loop(&ch, &handle)).await;
 
         assert!(state.sent_messages().is_empty());
+    }
+
+    #[tokio::test]
+    async fn poll_loop_uses_configured_poll_timeout() {
+        tokio::time::pause();
+        let state = FakeTelegram::new(vec![Ok(())]).with_poll_results(vec![vec![Update {
+            update_id: 1,
+            message: Some(TgMessage {
+                message_id: 1,
+                chat: Chat { id: CHAT_ID },
+                text: Some("hello".into()),
+            }),
+        }]]);
+        let ch = TelegramChannel::new(fake_client(&state), CHAT_ID, 60);
+        let (handle, _dir) = spawn_handle(vec![Ok(AgentResponse::Text("reply".into()))]);
+
+        let _ = tokio::time::timeout(Duration::from_millis(100), poll_loop(&ch, &handle)).await;
+
+        assert_eq!(state.last_poll_timeout(), Some(60));
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -113,7 +113,11 @@ pub fn build(config: &Config, workspace: &Workspace) -> Runtime {
         let notifier = build_notifier(&tg_client, config, workspace);
         tools.push(Arc::new(NotifyTool(notifier.clone())));
         (
-            Some(TelegramChannel::new(tg_client, config.telegram.chat_id)),
+            Some(TelegramChannel::new(
+                tg_client,
+                config.telegram.chat_id,
+                config.telegram.poll_timeout_secs,
+            )),
             Some(notifier),
         )
     } else {


### PR DESCRIPTION
The `telegram.poll_timeout_secs` config field (default 30, validated > 0) only affected the HTTP client timeout. The actual `getUpdates` long-poll `timeout` parameter was hardcoded to 30 in `poll_loop`. This threads the configured value through `TelegramChannel` and passes it to `poll_updates`, keeping the HTTP client timeout at `poll_timeout_secs + 10` as before.

Closes #7