### PR TITLE
Warm cargo builds: shared target dir, mold, warm coverage, cache hygiene

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.cargo
 
 commit-message.txt
 kitaebot.qcow2

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ nix develop              # Enter dev shell
 just check               # Full validation: nix flake check, nix lint/fmt, clippy, tests
 just rust-check          # Fast inner loop: cargo fmt-check + clippy + tests (not the commit gate)
 just build               # Compile
+just warm                # Warm the shared cargo target dir and sweep stale artifacts
 just test                # Run tests (mock-network feature)
 just test-e2e            # E2e suite: real daemon against a loopback fixture server
 just test-one NAME       # Run tests matching a name
@@ -184,7 +185,7 @@ kitaebot = {
       enabled = true;                            # Enables git tools (clone, commit, push)
       co_authors = [ "Name <email>" ];
       repositories = {                           # Listing a repo trusts its .envrc (direnv allow)
-        "owner/repo".check = "just check";       # The repo's check command; warms its build cache (spec 03)
+        "owner/repo".check = "just check; just warm"; # Check command; warms nix store + cargo target dir (spec 03)
         "owner/other" = { };                     # Trust-only entry (no check command)
       };
     };

--- a/deploy/configuration.nix
+++ b/deploy/configuration.nix
@@ -70,7 +70,7 @@ in
         enabled = true;
         co_authors = [ "Austin Mackillop <github.roundworm216@passmail.net>" ];
         repositories = {
-          "amackillop/kitaebot".check = "just check";
+          "amackillop/kitaebot".check = "just check; just warm";
           "CumuloGlobal/open-money".check = "just check";
           "CumuloGlobal/unhuman".check = "just check";
         };

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,13 @@
         commonArgs = {
           inherit src;
           strictDeps = true;
+          # Link with mold in the nix sandbox. Working-tree builds get
+          # it via .cargo/config.toml + the devShell package below.
+          RUSTFLAGS = [
+            "-C"
+            "link-arg=-fuse-ld=mold"
+          ];
+          nativeBuildInputs = [ pkgs.mold ];
         };
 
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
@@ -124,6 +131,10 @@
             just
             jq
             rust-analyzer
+            # Linker
+            mold
+            # Cache hygiene
+            cargo-sweep
             # Nix tooling
             nixfmt-rfc-style
             statix

--- a/justfile
+++ b/justfile
@@ -27,6 +27,11 @@ check-nix:
 build:
     cargo build
 
+# Warm the cargo target dir and sweep stale artifacts (spec 03 Build Warm)
+warm:
+    cargo build --tests --features mock-network
+    cargo sweep --time 7
+
 # Run tests
 test:
     cargo test --features mock-network

--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -508,8 +508,35 @@ Repos without one warm the devshell and nothing else.
 
 ```toml
 [git.repositories."amackillop/kitaebot"]
-check = "just check"
+check = "just check; just warm"
 ```
+
+### Cargo Target Dir
+
+A shared `CARGO_TARGET_DIR` at `workspace/projects/target` replaces
+per-repo `target/` dirs. Set in the daemon's systemd environment and
+added to `SAFE_ENV_VARS` so `safe_env()` lets it through to exec
+children, warm commands, and git hooks. Placed under `projects/` so
+the exec Landlock tier (which grants `all` on `projects/`) can write
+it; the workspace root is list-only. Survives `git clean -fdx` by
+construction — the clean runs inside individual repo dirs, and
+`projects/target` is a sibling, not a child. Per-repo `target/` is no
+longer in `KEPT_CACHES` and is swept on clean.
+
+The warm command's cargo step (`just warm`: `cargo build --tests
+--features mock-network && cargo sweep --time 7`) populates the shared dir and sweeps artifacts
+older than 7 days. `cargo-sweep` runs on the shared dir; cross-repo
+collisions are a known cargo hazard (upstream #14135) accepted because
+the agent serializes turns and the daily warm covers the cycle.
+
+### Linker
+
+mold is the linker for both working-tree and nix store builds.
+Working-tree: `.cargo/config.toml` sets target rustflags to pass
+`-fuse-ld=mold` to gcc; mold is on the devShell PATH. Nix store:
+`commonArgs` in `flake.nix` sets `RUSTFLAGS` and `nativeBuildInputs`
+with mold, so crane checks link with mold in the sandbox. Build
+scripts and proc-macros (host-compiled) still use the default linker.
 
 ## Boundaries
 
@@ -568,13 +595,6 @@ and a valid GitHub PAT loaded from credentials.
   silently when a repo renames its check; a machine-readable convention
   in the repo would be self-service but needs every repo to adopt it.
   Configured while there are two repos.
-- **Rooting the warm**: nothing holds a gcroot on what a warm builds —
-  the command is opaque (`just check`, a package script), not a
-  `nix build` with an out-link — so GC can evict it. GC is
-  pressure-triggered only ([spec 09](09-vm.md#garbage-collection)), so
-  eviction takes disk pressure, not a timer. Whether rooting needs
-  solving beyond that needs the [spec 24](24-self-directed-work.md)
-  duties running first.
 - **Read-before-edit precondition**: opencode-style enforcement
   (reject edits to files not yet read this session) would prevent
   blind edits but needs per-session read tracking in the harness. The

--- a/src/channel/execution_checkout.rs
+++ b/src/channel/execution_checkout.rs
@@ -40,7 +40,7 @@ pub(super) async fn prepare(git: &GitCli, nwo: &str) -> Result<String, ToolError
 
 /// In-repo caches the per-turn clean must not touch: re-provisioning
 /// them costs far more than tolerating a stale entry.
-const KEPT_CACHES: &[&str] = &[".direnv", "node_modules", "target", ".venv"];
+const KEPT_CACHES: &[&str] = &[".direnv", "node_modules", ".venv"];
 
 /// URL-parametrized body of [`prepare`], so tests can use `file://`.
 async fn prepare_at(git: &GitCli, url: &str, rel: &str) -> Result<(), ToolError> {
@@ -210,8 +210,8 @@ mod tests {
             ".direnv must survive the clean"
         );
         assert!(
-            checkout.join("target/lib.rlib").exists(),
-            "target must survive the clean"
+            !checkout.join("target/lib.rlib").exists(),
+            "target must be swept — shared CARGO_TARGET_DIR replaces per-repo target"
         );
         assert!(
             !checkout.join("stale.log").exists(),

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -89,6 +89,8 @@ const SAFE_ENV_VARS: &[&str] = &[
     "no_proxy",
     // Workspace
     "KITAEBOT_WORKSPACE",
+    // Build
+    "CARGO_TARGET_DIR",
     // GPG
     "GNUPGHOME",
     // Misc

--- a/vm/configuration.nix
+++ b/vm/configuration.nix
@@ -418,6 +418,9 @@ in
           };
           environment = {
             KITAEBOT_WORKSPACE = "/var/lib/kitaebot";
+            # Shared cargo target dir (spec 03 Build Warm). Under
+            # projects/ so the exec Landlock tier can write it.
+            CARGO_TARGET_DIR = "/var/lib/kitaebot/projects/target";
             RUST_LOG = cfg.logLevel;
             PATH = lib.mkForce toolPath;
             # All egress via the allowlisting forward proxy. Both cases


### PR DESCRIPTION
## Summary

Four changes to warm cargo builds: shared `CARGO_TARGET_DIR`, mold linker, cargo warm coverage, and cache hygiene.

### Commits

1. **Set shared CARGO_TARGET_DIR at daemon startup** — `workspace/projects/target` placed inside the Landlock `projects/` grant. Set as daemon-level env var + added to `SAFE_ENV_VARS` so `safe_env()` lets it through to all children.
2. **Remove target from KEPT_CACHES** — per-repo `target/` is dead with a shared dir; `git clean -fdx` sweeps it.
3. **Add mold linker** — `.cargo/config.toml` for working-tree builds, `RUSTFLAGS` + `nativeBuildInputs` in `commonArgs` for nix store builds. `mold` in devShell.
4. **Add cargo warm, cache hygiene, update docs** — `just warm` recipe (`cargo build --tests && cargo sweep --time 7`), `cargo-sweep` in devShell, updated `deploy/configuration.nix` warm command, spec 03, and README.

Closes #9