### PR TITLE
Add exponential backoff to Telegram poll loop on 429/5xx

### DIFF
--- a/specs/10-channels.md
+++ b/specs/10-channels.md
@@ -36,7 +36,9 @@ messages (fire-and-forget, errors logged). Resets on daemon restart.
 (1s, 2s, 4s) for transient errors (network, 429, 5xx).
 
 **Error handling**: `getUpdates` network errors trigger a 5-second sleep then
-retry. Other API errors are logged and the loop continues.
+retry. Transient API errors (429, 5xx) use exponential backoff (1s, 2s, 4s,
+capped at 60s) and respect Telegram's `retry_after` when present. Other API
+errors are logged and the loop continues immediately.
 
 **Preformatted output**: replies with `preformatted: true` are HTML-escaped
 and wrapped in `<pre>` tags.

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -21,6 +21,9 @@ use crate::error::TelegramError;
 /// Maximum retries for `sendMessage` on transient failures.
 const SEND_RETRIES: u32 = 3;
 
+/// Cap for poll-loop exponential backoff (1s, 2s, 4s, ..., 60s).
+const MAX_POLL_BACKOFF_SECS: u64 = 60;
+
 /// Telegram Bot API channel.
 ///
 /// Wraps a [`TelegramClient`] and the chat routing configuration.
@@ -111,6 +114,19 @@ fn is_transient(err: &TelegramError) -> bool {
     }
 }
 
+/// Backoff delay for a transient poll-loop error.
+///
+/// Respects Telegram's `retry_after` when present (429 responses).
+/// Otherwise uses exponential backoff from `attempts`: 1s, 2s, 4s,
+/// capped at 60s.
+fn poll_backoff(err: &TelegramError, attempts: u32) -> Duration {
+    if let Some(secs) = err.retry_after() {
+        return Duration::from_secs(secs);
+    }
+    let secs = u64::from(1u32 << attempts.min(6));
+    Duration::from_secs(MAX_POLL_BACKOFF_SECS.min(secs))
+}
+
 // --- Poll loop ---
 
 /// Run the Telegram long-poll loop until cancelled.
@@ -122,6 +138,7 @@ pub async fn poll_loop(channel: &TelegramChannel, handle: &AgentHandle) -> ! {
     info!(chat_id = channel.chat_id(), "Telegram poller starting");
     let mut offset: i64 = 0;
     let mut verbose = false;
+    let mut backoff_attempts: u32 = 0;
 
     loop {
         let updates = match channel
@@ -135,11 +152,20 @@ pub async fn poll_loop(channel: &TelegramChannel, handle: &AgentHandle) -> ! {
                 tokio::time::sleep(Duration::from_secs(5)).await;
                 continue;
             }
+            Err(e) if is_transient(&e) => {
+                let delay = poll_backoff(&e, backoff_attempts);
+                backoff_attempts = backoff_attempts.saturating_add(1);
+                error!("Telegram API error: {e}; retrying in {delay:?}");
+                tokio::time::sleep(delay).await;
+                continue;
+            }
             Err(e) => {
                 error!("Telegram API error: {e}");
                 continue;
             }
         };
+
+        backoff_attempts = 0;
 
         for update in updates {
             offset = update.update_id + 1;
@@ -240,7 +266,9 @@ mod tests {
 
     use super::*;
     use crate::clients::RawResponse;
-    use crate::clients::telegram::{ApiResponse, Chat, TelegramClient, TgMessage, Update};
+    use crate::clients::telegram::{
+        ApiResponse, Chat, ResponseParameters, TelegramClient, TgMessage, Update,
+    };
     use crate::provider::MockProvider;
     use crate::test_support::{TestAgent, workspace};
     use crate::types::Response as AgentResponse;
@@ -301,16 +329,20 @@ mod tests {
                 result: Some(result),
                 error_code: None,
                 description: None,
+                parameters: None,
             })
             .unwrap()
         }
 
-        fn error_json(error_code: i32, description: &str) -> Vec<u8> {
+        fn error_json(error_code: i32, description: &str, retry_after: Option<u64>) -> Vec<u8> {
             serde_json::to_vec(&ApiResponse::<serde_json::Value> {
                 ok: false,
                 result: None,
                 error_code: Some(error_code),
                 description: Some(description.into()),
+                parameters: retry_after.map(|secs| ResponseParameters {
+                    retry_after: Some(secs),
+                }),
             })
             .unwrap()
         }
@@ -358,9 +390,14 @@ mod tests {
                             Err(TelegramError::Api {
                                 error_code,
                                 description,
+                                retry_after,
                             }) => Ok(RawResponse {
                                 status: 200,
-                                body: FakeTelegram::error_json(*error_code, description),
+                                body: FakeTelegram::error_json(
+                                    *error_code,
+                                    description,
+                                    *retry_after,
+                                ),
                             }),
                             Err(TelegramError::Network(msg)) => {
                                 Err(TelegramError::Network(msg.clone()))
@@ -370,7 +407,7 @@ mod tests {
                             }
                             Err(TelegramError::Session(msg)) => Ok(RawResponse {
                                 status: 200,
-                                body: FakeTelegram::error_json(0, msg),
+                                body: FakeTelegram::error_json(0, msg, None),
                             }),
                         }
                     }
@@ -404,16 +441,42 @@ mod tests {
         assert!(is_transient(&TelegramError::Api {
             error_code: 500,
             description: "Internal Server Error".into(),
+            retry_after: None,
         }));
         assert!(is_transient(&TelegramError::Api {
             error_code: 429,
             description: "Too Many Requests".into(),
+            retry_after: None,
         }));
         assert!(!is_transient(&TelegramError::Api {
             error_code: 400,
             description: "Bad Request".into(),
+            retry_after: None,
         }));
         assert!(!is_transient(&TelegramError::Session("test".into())));
+    }
+
+    #[test]
+    fn poll_backoff_respects_retry_after() {
+        let err = TelegramError::Api {
+            error_code: 429,
+            description: "Too Many Requests".into(),
+            retry_after: Some(10),
+        };
+        assert_eq!(poll_backoff(&err, 0), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn poll_backoff_exponential_without_retry_after() {
+        let err = TelegramError::Api {
+            error_code: 500,
+            description: "Internal Server Error".into(),
+            retry_after: None,
+        };
+        assert_eq!(poll_backoff(&err, 0), Duration::from_secs(1));
+        assert_eq!(poll_backoff(&err, 1), Duration::from_secs(2));
+        assert_eq!(poll_backoff(&err, 2), Duration::from_secs(4));
+        assert_eq!(poll_backoff(&err, 6), Duration::from_mins(1));
     }
 
     #[test]
@@ -451,6 +514,7 @@ mod tests {
             Err(TelegramError::Api {
                 error_code: 429,
                 description: "Too Many Requests".into(),
+                retry_after: None,
             }),
             Ok(()),
         ]);
@@ -466,6 +530,7 @@ mod tests {
         let state = FakeTelegram::new(vec![Err(TelegramError::Api {
             error_code: 400,
             description: "Bad Request".into(),
+            retry_after: None,
         })]);
         let ch = channel(&state);
 

--- a/src/clients/telegram.rs
+++ b/src/clients/telegram.rs
@@ -128,11 +128,13 @@ pub fn interpret_response<T: DeserializeOwned>(raw: &RawResponse) -> Result<T, T
         api_response.result.ok_or_else(|| TelegramError::Api {
             error_code: 0,
             description: "ok=true but missing result".into(),
+            retry_after: None,
         })
     } else {
         Err(TelegramError::Api {
             error_code: api_response.error_code.unwrap_or(0),
             description: api_response.description.unwrap_or_default(),
+            retry_after: api_response.parameters.as_ref().and_then(|p| p.retry_after),
         })
     }
 }
@@ -151,6 +153,16 @@ pub(crate) struct ApiResponse<T> {
     pub(crate) result: Option<T>,
     pub(crate) error_code: Option<i32>,
     pub(crate) description: Option<String>,
+    #[serde(default)]
+    pub(crate) parameters: Option<ResponseParameters>,
+}
+
+/// `parameters` field Telegram includes in error responses.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct ResponseParameters {
+    /// Seconds to wait before retrying (429 responses).
+    #[serde(default)]
+    pub(crate) retry_after: Option<u64>,
 }
 
 /// A single incoming update from `getUpdates`.
@@ -209,6 +221,7 @@ mod tests {
             result: Some(updates),
             error_code: None,
             description: None,
+            parameters: None,
         })
         .unwrap()
     }
@@ -223,6 +236,7 @@ mod tests {
             }),
             error_code: None,
             description: None,
+            parameters: None,
         })
         .unwrap()
     }
@@ -233,6 +247,7 @@ mod tests {
             result: None,
             error_code: Some(code),
             description: Some(desc.into()),
+            parameters: None,
         })
         .unwrap()
     }
@@ -302,6 +317,26 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn interpret_429_captures_retry_after() {
+        let json = serde_json::json!({
+            "ok": false,
+            "error_code": 429,
+            "description": "Too Many Requests: retry after 5",
+            "parameters": { "retry_after": 5 }
+        })
+        .to_string();
+        let err = interpret_response::<Vec<Update>>(&raw(&json)).unwrap_err();
+        assert_eq!(err.retry_after(), Some(5));
+    }
+
+    #[test]
+    fn interpret_429_without_retry_after_defaults_to_none() {
+        let json = api_error_json(429, "Too Many Requests");
+        let err = interpret_response::<Vec<Update>>(&raw(&json)).unwrap_err();
+        assert_eq!(err.retry_after(), None);
     }
 
     // -- Client integration tests via from_fn --

--- a/src/error.rs
+++ b/src/error.rs
@@ -235,6 +235,8 @@ pub enum TelegramError {
     Api {
         error_code: i32,
         description: String,
+        /// Seconds Telegram asked us to wait before retrying (429 only).
+        retry_after: Option<u64>,
     },
 
     /// Failed to deserialize a Telegram API response body.
@@ -249,6 +251,18 @@ pub enum TelegramError {
     #[cfg(test)]
     #[error("Session error: {0}")]
     Session(String),
+}
+
+impl TelegramError {
+    /// Seconds to wait before retrying, when Telegram's 429 response
+    /// included `parameters.retry_after`. `None` for non-429 errors or
+    /// when the field was absent.
+    pub fn retry_after(&self) -> Option<u64> {
+        match self {
+            Self::Api { retry_after, .. } => *retry_after,
+            _ => None,
+        }
+    }
 }
 
 /// GitHub REST API errors.


### PR DESCRIPTION
The poll loop's catch-all `Err(e)` arm tight-looped on transient API errors (429, 5xx) with no delay, hammering Telegram as fast as `getUpdates` returned and flooding the error log. The `send_raw` path already had exponential backoff; the poll path did not.

Changes:
- Split the poll-loop catch-all: transient errors (429/5xx) now sleep with exponential backoff (1s, 2s, 4s, ..., capped at 60s) from a consecutive-failure counter that resets on the next successful poll. Non-transient errors still continue immediately.
- Capture Telegram's `parameters.retry_after` from 429 responses: added `ResponseParameters` to `ApiResponse`, propagated `retry_after` through `TelegramError::Api`. `poll_backoff` honors `retry_after` when present, overriding the exponential schedule.
- The Network arm (5s fixed sleep) is unchanged; network errors neither consume nor reset the backoff counter.
- Spec 10-channels.md updated to document the new error-handling behavior.

Closes #15