### PR TITLE
Set shared CARGO_TARGET_DIR for working-tree builds

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -512,6 +512,22 @@ Repos without one warm the devshell and nothing else.
 check = "just check"
 ```
 
+### Cargo Target Dir
+
+A shared `CARGO_TARGET_DIR` at `workspace/projects/target` replaces
+per-repo `target/` dirs. Set in the daemon's systemd environment
+(`vm/configuration.nix`) and added to `SAFE_ENV_VARS` so `safe_env()`
+lets it through to exec children, warm commands, and git hooks.
+Placed under `projects/` so the exec Landlock tier (which grants `all`
+on `projects/`) can write it; the workspace root is list-only.
+Survives `git clean -fdx` by construction — the clean runs inside
+individual repo dirs, and `projects/target` is a sibling, not a
+child. Per-repo `target/` is no longer in `KEPT_CACHES` and is swept
+on clean.
+
+The devShell does not set `CARGO_TARGET_DIR`, so the systemd
+environment is the sole source — direnv does not override it.
+
 ## Boundaries
 
 ### Owns

--- a/src/channel/execution_checkout.rs
+++ b/src/channel/execution_checkout.rs
@@ -40,7 +40,7 @@ pub(super) async fn prepare(git: &GitCli, nwo: &str) -> Result<String, ToolError
 
 /// In-repo caches the per-turn clean must not touch: re-provisioning
 /// them costs far more than tolerating a stale entry.
-const KEPT_CACHES: &[&str] = &[".direnv", "node_modules", "target", ".venv"];
+const KEPT_CACHES: &[&str] = &[".direnv", "node_modules", ".venv"];
 
 /// URL-parametrized body of [`prepare`], so tests can use `file://`.
 async fn prepare_at(git: &GitCli, url: &str, rel: &str) -> Result<(), ToolError> {
@@ -210,8 +210,8 @@ mod tests {
             ".direnv must survive the clean"
         );
         assert!(
-            checkout.join("target/lib.rlib").exists(),
-            "target must survive the clean"
+            !checkout.join("target/lib.rlib").exists(),
+            "target must be swept — shared CARGO_TARGET_DIR replaces per-repo target"
         );
         assert!(
             !checkout.join("stale.log").exists(),

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -89,6 +89,8 @@ const SAFE_ENV_VARS: &[&str] = &[
     "no_proxy",
     // Workspace
     "KITAEBOT_WORKSPACE",
+    // Build
+    "CARGO_TARGET_DIR",
     // GPG
     "GNUPGHOME",
     // Misc

--- a/vm/configuration.nix
+++ b/vm/configuration.nix
@@ -419,6 +419,9 @@ in
           };
           environment = {
             KITAEBOT_WORKSPACE = "/var/lib/kitaebot";
+            # Shared cargo target dir (spec 03 Build Warm). Under
+            # projects/ so the exec Landlock tier can write it.
+            CARGO_TARGET_DIR = "/var/lib/kitaebot/projects/target";
             RUST_LOG = cfg.logLevel;
             PATH = lib.mkForce toolPath;
             # All egress via the allowlisting forward proxy. Both cases


### PR DESCRIPTION
Working-tree cargo builds start from a cold `./target` in every fresh checkout and repeatedly hit the exec 600s timeout. Give all repos one shared target dir at `workspace/projects/target`.

Changes:
- Set `CARGO_TARGET_DIR` in the daemon's systemd environment (`vm/configuration.nix`) and add it to `SAFE_ENV_VARS` so `safe_env()` lets it through to exec children, warm commands, and git hooks. Placed under `projects/` so the exec Landlock tier (which grants `all` on `projects/`) can write it; the workspace root is list-only. Survives `git clean -fdx` by construction — the clean runs inside individual repo dirs, and `projects/target` is a sibling, not a child.
- Remove `target` from `KEPT_CACHES` (introduced in 4796a4d to keep `.direnv`, `node_modules`, `target`, `.venv` across per-turn clean). Per-repo `target/` is dead with a shared dir; sweeping it on clean is correct. Test assertion updated.
- The devShell does not set `CARGO_TARGET_DIR` (confirmed: `flake.nix` and `.envrc` have no reference), so the systemd environment is the sole source — direnv does not override it.
- Spec 03 updated with a Cargo Target Dir section.

Closes #12