### PR TITLE
Link with mold for working-tree and nix store builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.cargo
 
 commit-message.txt
 kitaebot.qcow2

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,12 @@
         commonArgs = {
           inherit src;
           strictDeps = true;
+          # Link with mold in the nix sandbox.
+          RUSTFLAGS = [
+            "-C"
+            "link-arg=-fuse-ld=mold"
+          ];
+          nativeBuildInputs = [ pkgs.mold ];
         };
 
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
@@ -124,6 +130,8 @@
             just
             jq
             rust-analyzer
+            # Linker
+            mold
             # Nix tooling
             nixfmt-rfc-style
             statix

--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -528,6 +528,16 @@ on clean.
 The devShell does not set `CARGO_TARGET_DIR`, so the systemd
 environment is the sole source — direnv does not override it.
 
+### Linker
+
+mold is the linker for both working-tree and nix store builds.
+Working-tree: `.cargo/config.toml` sets target rustflags to pass
+`-fuse-ld=mold` to gcc; mold is on the devShell PATH. Nix store:
+`commonArgs` in `flake.nix` sets `RUSTFLAGS` and `nativeBuildInputs`
+with mold, so crane checks link with mold in the sandbox. The final
+crate link is the dominant cost; build scripts and proc-macros link
+fast regardless of linker.
+
 ## Boundaries
 
 ### Owns


### PR DESCRIPTION
Link time dominates cold `cargo test` runs on the VM and no cache covers linking. Adopt mold as the linker.

Changes:
- Working-tree: `.cargo/config.toml` sets target rustflags to pass `-fuse-ld=mold` to gcc for `x86_64-unknown-linux-gnu`; mold is on the devShell PATH. The `.gitignore` `.*` pattern ignores `.cargo/`, so add a `!.cargo` exception to track the config.
- Nix store: `commonArgs` in `flake.nix` sets `RUSTFLAGS` with `-C link-arg=-fuse-ld=mold` and `nativeBuildInputs` with `pkgs.mold`, so crane checks link with mold in the sandbox too.
- The final crate link is the dominant cost; build scripts and proc-macros link fast regardless of linker.
- Spec 03 updated with a Linker section.

Closes #13