### PR TITLE
Tolerate stringified review param in task tool

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -33,6 +33,12 @@ call `execute` with a clone of the turn's `ToolCtx`. Unknown tool name
 returns `ToolError::NotFound`. Malformed arguments return
 `ToolError::InvalidArguments`.
 
+The LLM sometimes passes a structured field as a JSON string instead of a
+JSON object (e.g. `"review": "{\"repo\":\"...\"}"` instead of
+`"review": {"repo":"..."}`). Fields prone to this use the `string_or_value`
+deserializer, which parses the inner JSON string before deserializing into
+the target type. Applied to `task`'s `review` parameter.
+
 ### Per-Turn Context
 
 `execute` receives a `ToolCtx` — the per-turn context the agent loop threads

--- a/src/agent/task.rs
+++ b/src/agent/task.rs
@@ -24,7 +24,7 @@ use crate::error::ToolError;
 use crate::provider::Provider;
 use crate::review::{self, ReviewLedger};
 use crate::tools::mcp::McpTools;
-use crate::tools::{Tool, ToolCtx, Tools};
+use crate::tools::{Tool, ToolCtx, Tools, string_or_value};
 use crate::usage::{self, TurnRecord, UsageLedger};
 
 use super::{BudgetPolicy, run_turn_metered};
@@ -209,7 +209,7 @@ struct Args {
     agent_type: AgentKind,
     /// Reviewer calls only: ledger context for the gate invocation.
     /// Ignored for other agent types.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "string_or_value")]
     review: Option<ReviewMeta>,
 }
 
@@ -926,6 +926,52 @@ mod tests {
     fn agent_type_defaults_to_explore() {
         let args: Args = serde_json::from_value(serde_json::json!({"prompt": "x"})).unwrap();
         assert_eq!(args.agent_type, AgentKind::Explore);
+    }
+
+    #[test]
+    fn review_field_accepts_object() {
+        let args: Args = serde_json::from_value(serde_json::json!({
+            "prompt": "x",
+            "review": {"repo": "o/r", "gate": "commit", "git_ref": "abc"}
+        }))
+        .unwrap();
+        let review = args.review.unwrap();
+        assert_eq!(review.repo, "o/r");
+        assert_eq!(review.gate, "commit");
+        assert_eq!(review.git_ref, "abc");
+    }
+
+    #[test]
+    fn review_field_accepts_stringified_json() {
+        let args: Args = serde_json::from_value(serde_json::json!({
+            "prompt": "x",
+            "review": "{\"repo\":\"o/r\",\"gate\":\"commit\",\"git_ref\":\"abc\"}"
+        }))
+        .unwrap();
+        let review = args.review.unwrap();
+        assert_eq!(review.repo, "o/r");
+        assert_eq!(review.gate, "commit");
+        assert_eq!(review.git_ref, "abc");
+    }
+
+    #[test]
+    fn review_field_accepts_null_string() {
+        let args: Args =
+            serde_json::from_value(serde_json::json!({"prompt": "x", "review": "null"})).unwrap();
+        assert!(args.review.is_none());
+    }
+
+    #[test]
+    fn review_field_accepts_null() {
+        let args: Args =
+            serde_json::from_value(serde_json::json!({"prompt": "x", "review": null})).unwrap();
+        assert!(args.review.is_none());
+    }
+
+    #[test]
+    fn review_field_absent_defaults_none() {
+        let args: Args = serde_json::from_value(serde_json::json!({"prompt": "x"})).unwrap();
+        assert!(args.review.is_none());
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -303,6 +303,34 @@ impl Tools {
 /// long before it approaches this ceiling.
 pub(crate) const TOOL_OUTPUT_CEILING_BYTES: usize = 5 * 1024 * 1024;
 
+/// Deserialize `Option<T>` tolerating a JSON string where an
+/// object/null is expected (LLM double-encoding). Parses the inner
+/// JSON before deserializing into `T`.
+pub(crate) fn string_or_value<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: serde::de::DeserializeOwned,
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    match value {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(s)) => {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&s).map_err(serde::de::Error::custom)?;
+            match parsed {
+                serde_json::Value::Null => Ok(None),
+                other => serde_json::from_value(other)
+                    .map(Some)
+                    .map_err(serde::de::Error::custom),
+            }
+        }
+        Some(other) => serde_json::from_value(other)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+    }
+}
+
 /// Truncate string at byte boundary without splitting UTF-8.
 ///
 /// If `s` exceeds `max_bytes`, it is cut at the nearest character boundary


### PR DESCRIPTION
The LLM sometimes passes the `task` tool's `review` field as a JSON string instead of a JSON object (e.g. `"review": "{\"repo\":\"...\"}"` instead of `"review": {"repo":"..."}`). Plain `serde_json::from_value` rejects this with "invalid type: string, expected struct ReviewMeta", forcing the agent to omit `review` entirely, which records findings without gate/ref/repo metadata.

Fix: add a `string_or_value` deserializer in `tools/mod.rs` that parses the inner JSON string before deserializing into the target type. Applied to the `task` tool's `review` field via `#[serde(deserialize_with = "string_or_value")]`. The helper is generic and reusable for other structured fields the LLM may double-encode.

Tests cover all four input shapes: object, stringified JSON, `"null"` string, null, and absent field.

Spec 03 updated to document the deserializer.

Closes #20