### PR TITLE
Tolerate stringified body in github_api tool

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -37,7 +37,8 @@ The LLM sometimes passes a structured field as a JSON string instead of a
 JSON object (e.g. `"review": "{\"repo\":\"...\"}"` instead of
 `"review": {"repo":"..."}`). Fields prone to this use the `string_or_value`
 deserializer, which parses the inner JSON string before deserializing into
-the target type. Applied to `task`'s `review` parameter.
+the target type. Applied to `task`'s `review` parameter and
+`github_api`'s `body` parameter.
 
 ### Per-Turn Context
 

--- a/src/tools/github/api.rs
+++ b/src/tools/github/api.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 
 use super::{GithubApi, Tool, ToolCtx, api_err};
 use crate::error::ToolError;
+use crate::tools::string_or_value;
 
 /// Resources the model may touch.
 const ALLOWED_RESOURCES: &[&str] = &["issues", "labels", "milestones", "pulls", "releases"];
@@ -47,6 +48,7 @@ struct Args {
     /// milestones, pulls, releases.
     path: String,
     /// JSON body for POST/PATCH.
+    #[serde(default, deserialize_with = "string_or_value")]
     body: Option<serde_json::Value>,
 }
 
@@ -192,5 +194,69 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out, r#"{"id":1}"#);
+    }
+
+    #[tokio::test]
+    async fn stringified_body_delivered_as_object() {
+        let api = stub_api_with_repo("owner/repo", |method, _path, body| {
+            assert_eq!(method, "POST");
+            let raw = body.unwrap();
+            // The raw bytes must be a JSON object, not a JSON string.
+            assert_eq!(raw[0], b'{', "body must start with '{{', got: {raw:?}");
+            let payload: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+            assert_eq!(payload["body"], "done");
+            br#"{"id":1}"#.to_vec()
+        });
+        let tool = Api(api);
+        // Simulate the LLM passing body as a stringified JSON string.
+        let args: Args = serde_json::from_value(serde_json::json!({
+            "repo_dir": "projects/r",
+            "method": "POST",
+            "path": "issues/42/comments",
+            "body": "{\"body\": \"done\"}"
+        }))
+        .unwrap();
+        let out = tool.run(&args).await.unwrap();
+        assert_eq!(out, r#"{"id":1}"#);
+    }
+
+    #[tokio::test]
+    async fn object_body_delivered_as_object() {
+        let api = stub_api_with_repo("owner/repo", |method, _path, body| {
+            assert_eq!(method, "POST");
+            let raw = body.unwrap();
+            assert_eq!(raw[0], b'{', "body must start with '{{', got: {raw:?}");
+            let payload: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+            assert_eq!(payload["body"], "done");
+            br#"{"id":1}"#.to_vec()
+        });
+        let tool = Api(api);
+        let args: Args = serde_json::from_value(serde_json::json!({
+            "repo_dir": "projects/r",
+            "method": "POST",
+            "path": "issues/42/comments",
+            "body": {"body": "done"}
+        }))
+        .unwrap();
+        let out = tool.run(&args).await.unwrap();
+        assert_eq!(out, r#"{"id":1}"#);
+    }
+
+    #[tokio::test]
+    async fn absent_body_delivered_as_none() {
+        let api = stub_api_with_repo("owner/repo", |method, _path, body| {
+            assert_eq!(method, "GET");
+            assert!(body.is_none(), "GET should have no body");
+            br"[]".to_vec()
+        });
+        let tool = Api(api);
+        let args: Args = serde_json::from_value(serde_json::json!({
+            "repo_dir": "projects/r",
+            "method": "GET",
+            "path": "issues?state=open"
+        }))
+        .unwrap();
+        let out = tool.run(&args).await.unwrap();
+        assert_eq!(out, r"[]");
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -304,8 +304,7 @@ impl Tools {
 pub(crate) const TOOL_OUTPUT_CEILING_BYTES: usize = 5 * 1024 * 1024;
 
 /// Deserialize `Option<T>` tolerating a JSON string where an
-/// object/null is expected (LLM double-encoding). Parses the inner
-/// JSON before deserializing into `T`.
+/// object/null is expected (LLM double-encoding).
 pub(crate) fn string_or_value<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
 where
     T: serde::de::DeserializeOwned,


### PR DESCRIPTION
The `github_api` tool double-encodes JSON bodies when the LLM passes the `body` parameter as a JSON string (e.g. `"body": "{\"body\": \"done\"}"`) instead of a JSON object. `serde_json::to_vec` on the resulting `Value::String` produces a JSON string `"{\"body\":\"done\"}"` instead of an object `{"body":"done"}`. GitHub rejects this with 422 "is not an object".

Fix: apply the `string_or_value` deserializer to the `body` field. If the value arrives as a string, it parses the inner JSON before deserializing into `Value`, ensuring `to_vec` always sees a `Value::Object`.

Tests assert the raw request body starts with `{` for both stringified and object inputs, and that a GET with no body delivers `None`.

Note: PR #21 (issue #20) adds the same `string_or_value` helper for the `task` tool's `review` field. If both merge, the second will need a trivial conflict resolution (both add the same function to the same location in `tools/mod.rs`).

Closes #10