### PR TITLE
Tolerate string-encoded offset/limit in file_read

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -33,12 +33,14 @@ call `execute` with a clone of the turn's `ToolCtx`. Unknown tool name
 returns `ToolError::NotFound`. Malformed arguments return
 `ToolError::InvalidArguments`.
 
-The LLM sometimes passes a structured field as a JSON string instead of a
-JSON object (e.g. `"review": "{\"repo\":\"...\"}"` instead of
-`"review": {"repo":"..."}`). Fields prone to this use the `string_or_value`
+The LLM sometimes passes a field as a JSON string instead of a
+JSON value (e.g. `"review": "{\"repo\":\"...\"}"` instead of
+`"review": {"repo":"..."}`, or `"limit": "30"` instead of
+`"limit": 30`). Fields prone to this use the `string_or_value`
 deserializer, which parses the inner JSON string before deserializing into
-the target type. Applied to `task`'s `review` parameter and
-`github_api`'s `body` parameter.
+the target type. Applied to `task`'s `review` parameter,
+`github_api`'s `body` parameter, and `file_read`'s `offset`/`limit`
+parameters.
 
 ### Per-Turn Context
 

--- a/src/tools/file_read.rs
+++ b/src/tools/file_read.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use tracing::{debug, warn};
 
 use super::path::PathGuard;
-use super::{Tool, ToolCtx};
+use super::{Tool, ToolCtx, string_or_value};
 use crate::error::ToolError;
 
 /// 10 MB — reject files larger than this to avoid flooding context.
@@ -26,8 +26,10 @@ struct Args {
     /// File path relative to the workspace.
     path: String,
     /// Start line (1-based). Defaults to 1.
+    #[serde(default, deserialize_with = "string_or_value")]
     offset: Option<u32>,
     /// Maximum number of lines to return. Defaults to 2000.
+    #[serde(default, deserialize_with = "string_or_value")]
     limit: Option<u32>,
 }
 
@@ -179,6 +181,23 @@ mod tests {
         let result = tool
             .execute(
                 serde_json::json!({"path": "test.txt", "offset": 2, "limit": 2}),
+                ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+        assert!(!result.contains("1\ta"));
+        assert!(result.contains("2\tb"));
+        assert!(result.contains("3\tc"));
+        assert!(!result.contains("4\td"));
+        assert!(result.contains("2 lines shown"));
+    }
+
+    #[tokio::test]
+    async fn read_with_string_encoded_offset_and_limit() {
+        let (_dir, tool) = setup("a\nb\nc\nd\ne\n");
+        let result = tool
+            .execute(
+                serde_json::json!({"path": "test.txt", "offset": "2", "limit": "2"}),
                 ToolCtx::default(),
             )
             .await

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -325,8 +325,8 @@ impl Tools {
 /// long before it approaches this ceiling.
 pub(crate) const TOOL_OUTPUT_CEILING_BYTES: usize = 5 * 1024 * 1024;
 
-/// Deserialize `Option<T>` tolerating a JSON string where an
-/// object/null is expected (LLM double-encoding).
+/// Deserialize `Option<T>` tolerating a JSON string where a
+/// value/null is expected (LLM double-encoding).
 pub(crate) fn string_or_value<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
 where
     T: serde::de::DeserializeOwned,


### PR DESCRIPTION
The LLM sometimes passes `file_read`'s `offset` or `limit` as a string (e.g. `"limit": "30"`) instead of a number. serde rejects this with "invalid type: string, expected u32".

Apply the existing `string_or_value` deserializer to both fields. The helper parses the inner JSON string before deserializing into `u32`, so `"30"` becomes `30`. Integer inputs pass through unchanged.

Widen the spec and helper doc comment from "object" to "value" since the deserializer now covers scalar fields too.

Closes #24