### PR TITLE
Run the supply-chain audit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run checks
         run: nix flake check --print-build-logs
 
+      - name: Supply-chain audit
+        run: nix develop --command just audit
+
   nixos-tests:
     name: NixOS VM tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI ran `nix flake check` but never `just audit`, so the Dependabot bumps merged green and then broke the audit gate on master (foldhash/Zlib). CI now runs the same audit the local gate runs, from the devshell — flake-pinned cargo-deny, same deny.toml, live advisory DB. A bump that shifts the license set or trips an advisory now fails its own PR instead of landing on master as a surprise.

This PR doubles as the live test that both the Cachix swap and the audit step are green in CI.