### PR TITLE
Gate warm duty on new commits per-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ kitaebot = {
     };
     duties = {                                   # Duty scheduler (spec 24)
       distill = { every = "1h"; };                # Token gate still applies
-      warm = { every = "24h"; };                  # Build-warm duty; runs only when some repo sets check
+      warm = { every = "24h"; };                  # Build-warm duty; warms repos whose HEAD moved (spec 24)
       self_analysis = {                           # Mine own errors/journal, propose fixes as issues
         every = "24h";
         repo = "owner/repo";                      # Must be trusted and proposal-enabled

--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -496,8 +496,12 @@ visible rather than inside a tool call.
 3. **Two triggers** — the self-maintenance duty
    ([spec 24](24-self-directed-work.md)) for configured repos, and
    checkout preparation for repos cloned on demand
-4. **Unconditional** — a warm-store run costs seconds; no bookkeeping
-   about whether it already happened
+4. **Unconditional per invocation** — a warm-store run itself costs
+   seconds and needs no bookkeeping about whether it already happened
+   (the `Warmer`'s `Notify` dedup handles concurrent callers). The
+   duty's *scheduling* is gated per-repo on new commits
+   ([spec 24](24-self-directed-work.md) warm duty), but each warm
+   invocation that the gate lets through runs unconditionally
 5. **Background** — never blocks the turn that triggered it
 6. **Readers wait, one runner** — a `Notify` per repo, as the direnv
    cache does. Nix serialises same-derivation builds anyway, but a

--- a/specs/24-self-directed-work.md
+++ b/specs/24-self-directed-work.md
@@ -126,8 +126,13 @@ Recurring mechanical work on the bot's own machine rather than on a
 repository. No LLM turn: the outcome is a log line, not a reply.
 
 - **Warm** — build each configured repo's checks, cloning the checkout
-  first if absent, so the commit gate never meets a cold store. Repos
-  warm sequentially: two cold builds would contend for the same cores.
+  first if absent, so the commit gate never meets a cold store. The
+  duty is gated per-repo on new commits: each tick probes the remote
+  HEAD via `ls-remote` and warms only repos whose HEAD moved past a
+  per-repo cursor (`warm/<nwo>` in the state DB), or that have no
+  cursor (enrollment) or no checkout. The cursor advances only on a
+  successful warm, so a failed warm retries next tick. Repos warm
+  sequentially: two cold builds would contend for the same cores.
   Contract and consumer: [spec 03](03-tools.md#build-warm).
 - **Workspace hygiene** (not built) — remove finished checkouts and
   the `.direnv` gcroots pinning their devShell closures. Review
@@ -323,6 +328,10 @@ complete scope statement for discovery and prompt duties, and its
   delta next period. No queue, no retry loop inside the turn.
 - **Symptom probe fails** (unreadable journal or error files): logged,
   duty retries next period; the cursor stays put.
+- **Warm ls-remote fails**: the repo is skipped with cursor untouched;
+  it retries next tick.
+- **Warm command fails**: cursor does not advance, so the repo retries
+  next tick.
 - **Proposal flood attempt** (a broken gate matching everything): the
   per-repo cap bounds damage to 3 open issues, and one filing per run
   bounds the rate; the injected open list bounds repeat noise.

--- a/src/duty/mod.rs
+++ b/src/duty/mod.rs
@@ -49,7 +49,7 @@ pub enum Action {
         repo: String,
         min_delta_tokens: usize,
     },
-    /// Prepare and warm every repo with a configured warm command, in
+    /// Probe and warm configured repos whose remote HEAD moved, in
     /// the scheduler with no LLM turn (spec 24 self-maintenance).
     Warm,
 }
@@ -247,7 +247,7 @@ async fn run_one(duty: &Duty, ctx: &RunCtx<'_>, state: &mut DutyState) {
         }
         Action::Warm => {
             let outcome = match ctx.git.as_ref() {
-                Some(git) => git.warm_configured_repos().await,
+                Some(git) => run_warm(git, state).await,
                 None => "skipped: no GitCli".into(),
             };
             info!(duty = %duty.name, "Duty run: {outcome}");
@@ -438,6 +438,52 @@ async fn probe_new_commits(
     }
 }
 
+/// Per-repo cursor key for the warm gate: `warm/<nwo>`.
+fn warm_cursor_key(nwo: &str) -> String {
+    format!("warm/{nwo}")
+}
+
+/// Run the warm duty with per-repo new-commits gating (spec 24).
+///
+/// Each configured repo is probed via `ls-remote`; only repos whose
+/// remote HEAD moved past the cursor (or that have no cursor or no
+/// checkout) are warmed. The cursor advances only on a successful
+/// warm, so a failed warm retries next tick. Returns a per-repo
+/// summary for the duty history log.
+async fn run_warm(git: &GitCli, state: &mut DutyState) -> String {
+    let repos = git.warm_repos();
+    if repos.is_empty() {
+        return "no warm commands configured".into();
+    }
+    let mut lines = Vec::with_capacity(repos.len());
+    for nwo in &repos {
+        let key = warm_cursor_key(nwo);
+        let cursor = state.cursor(&key);
+        // Fetch the remote HEAD once: the gate decision and the
+        // cursor advance both need it.
+        let head = match git.remote_head(nwo).await {
+            Ok(h) => h,
+            Err(e) => {
+                error!(repo = %nwo, "warm gate ls-remote failed: {e}");
+                lines.push(format!("{nwo}: skipped (ls-remote failed)"));
+                continue;
+            }
+        };
+        // Due when: no cursor (enrollment), no checkout, or HEAD moved.
+        let due = cursor.is_none() || !git.checkout_exists(nwo) || cursor != Some(head.as_str());
+        if !due {
+            lines.push(format!("{nwo}: skipped (no new commits)"));
+            continue;
+        }
+        let status = git.prepare_and_warm(nwo).await;
+        if status == "warm" {
+            state.set_cursor(&key, &head);
+        }
+        lines.push(format!("{nwo}: {status}"));
+    }
+    lines.join("; ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -521,5 +567,208 @@ mod tests {
         let state = DutyState::default();
         // Everything due now: still sleeps at least a second.
         assert_eq!(next_wake(&duties(), &state, 1_000), 1);
+    }
+
+    // --- warm gate tests ---
+
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use crate::secrets::Secret;
+    use crate::test_support::FakeDirenv;
+    use crate::tools::Warmer;
+
+    /// Run a git command in `cwd`, asserting success, returning stdout.
+    fn git_cmd(args: &[&str], cwd: &std::path::Path) -> String {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} in {} failed: {}",
+            args,
+            cwd.display(),
+            String::from_utf8_lossy(&out.stderr),
+        );
+        String::from_utf8(out.stdout).unwrap()
+    }
+
+    /// A bare repo at `<workspace>/o/r.git` with one commit, and an
+    /// existing checkout at `<workspace>/projects/o/r` with `.envrc`,
+    /// so `ls-remote` returns a real HEAD SHA and `prepare_and_warm`
+    /// can provision the devshell. The `GitCli` uses `with_clone_base`
+    /// pointing at the workspace root via `file://` so `repo_url("o/r")`
+    /// resolves to the bare repo.
+    fn warm_test_setup(warm_command: &str) -> (GitCli, std::path::PathBuf, String) {
+        let workspace = tempfile::tempdir().unwrap();
+        let ws = workspace.path().to_path_buf();
+
+        // Create a non-bare repo with one commit, then clone --bare.
+        // This avoids cross-device link errors from pushing to a
+        // bare repo that was cloned empty.
+        let src = ws.join("o/r-src");
+        std::fs::create_dir_all(&src).unwrap();
+        git_cmd(&["init", src.to_str().unwrap()], &ws);
+        for (k, v) in [
+            ("user.email", "t@t"),
+            ("user.name", "t"),
+            ("commit.gpgsign", "false"),
+        ] {
+            git_cmd(&["config", k, v], &src);
+        }
+        std::fs::write(src.join("README"), "init").unwrap();
+        std::fs::write(src.join(".envrc"), "use flake").unwrap();
+        git_cmd(&["add", "."], &src);
+        git_cmd(&["commit", "-m", "init"], &src);
+
+        // Clone to bare — same filesystem, no cross-device issue.
+        let bare = ws.join("o/r.git");
+        git_cmd(
+            &[
+                "clone",
+                "--bare",
+                src.to_str().unwrap(),
+                bare.to_str().unwrap(),
+            ],
+            &ws,
+        );
+
+        // Create the checkout that `prepare_and_warm` expects.
+        let checkout = ws.join("projects/o/r");
+        git_cmd(
+            &["clone", bare.to_str().unwrap(), checkout.to_str().unwrap()],
+            &ws,
+        );
+        // Set origin to a GitHub URL so `origin_nwo` resolves.
+        git_cmd(
+            &["remote", "set-url", "origin", "https://github.com/o/r.git"],
+            &checkout,
+        );
+
+        // Get the HEAD sha from the bare repo.
+        let head = git_cmd(&["rev-parse", "HEAD"], &bare);
+        let head = head.trim().to_string();
+
+        // Leak the workspace and direnv tempdir so they outlive this
+        // helper (same pattern as workspace_with_checkout in git_cli).
+        let ws = workspace.keep();
+        let direnv = FakeDirenv::install("echo '{}'");
+        let direnv_cache = direnv.cache();
+        std::mem::forget(direnv);
+        let commands: BTreeMap<String, String> =
+            [("o/r".to_string(), warm_command.to_string())].into();
+        let git = GitCli::new(
+            Secret::test("fake"),
+            ws.clone(),
+            direnv_cache.clone(),
+            vec!["o/r".into()],
+        )
+        .with_clone_base(&format!("file://{}", ws.to_str().unwrap()))
+        .with_warm(Warmer::new(direnv_cache), Arc::new(commands));
+
+        (git, ws, head)
+    }
+
+    #[tokio::test]
+    async fn warm_gate_skips_when_cursor_matches_head() {
+        let (git, _ws, head) = warm_test_setup("touch .warmed");
+        let mut state = DutyState::default();
+        state.set_cursor(&warm_cursor_key("o/r"), &head);
+
+        let summary = run_warm(&git, &mut state).await;
+
+        assert!(
+            summary.contains("skipped (no new commits)"),
+            "unchanged cursor must skip: {summary}"
+        );
+        assert_eq!(state.cursor(&warm_cursor_key("o/r")), Some(head.as_str()));
+    }
+
+    #[tokio::test]
+    async fn warm_gate_warms_when_head_moved() {
+        let (git, ws, head) = warm_test_setup("touch .warmed");
+        let mut state = DutyState::default();
+        state.set_cursor(&warm_cursor_key("o/r"), "stale-sha");
+
+        let summary = run_warm(&git, &mut state).await;
+
+        assert!(
+            summary.contains("o/r: warm"),
+            "moved HEAD must warm: {summary}"
+        );
+        assert_eq!(state.cursor(&warm_cursor_key("o/r")), Some(head.as_str()));
+        let warmed = ws.join("projects/o/r/.warmed");
+        assert!(warmed.exists(), "warm command must have run");
+    }
+
+    #[tokio::test]
+    async fn warm_gate_warms_enrollment_no_cursor() {
+        let (git, ws, head) = warm_test_setup("touch .warmed");
+        let mut state = DutyState::default();
+
+        let summary = run_warm(&git, &mut state).await;
+
+        assert!(
+            summary.contains("o/r: warm"),
+            "no cursor must warm (enrollment): {summary}"
+        );
+        assert_eq!(state.cursor(&warm_cursor_key("o/r")), Some(head.as_str()));
+        let warmed = ws.join("projects/o/r/.warmed");
+        assert!(warmed.exists(), "warm command must have run");
+    }
+
+    #[tokio::test]
+    async fn warm_gate_warms_when_checkout_missing() {
+        let (git, ws, head) = warm_test_setup("touch .warmed");
+        let mut state = DutyState::default();
+        state.set_cursor(&warm_cursor_key("o/r"), &head);
+
+        // Remove the checkout so the gate sees it as missing.
+        std::fs::remove_dir_all(ws.join("projects/o/r")).unwrap();
+
+        // The gate sees no checkout and marks the repo due. The warm
+        // clones from the file:// bare repo, but origin_nwo won't
+        // resolve for a file:// clone, so prepare_and_warm returns a
+        // skip status — the gate decision is what we test here.
+        let summary = run_warm(&git, &mut state).await;
+
+        assert!(
+            !summary.contains("skipped (no new commits)"),
+            "missing checkout must not be skipped: {summary}"
+        );
+        assert_eq!(state.cursor(&warm_cursor_key("o/r")), Some(head.as_str()));
+    }
+
+    #[tokio::test]
+    async fn warm_gate_does_not_advance_cursor_on_failure() {
+        let (git, _ws, _head) = warm_test_setup("exit 1");
+        let mut state = DutyState::default();
+
+        let summary = run_warm(&git, &mut state).await;
+
+        assert!(
+            summary.contains("o/r: failed"),
+            "failing command must report failed: {summary}"
+        );
+        assert_eq!(state.cursor(&warm_cursor_key("o/r")), None);
+    }
+
+    #[tokio::test]
+    async fn warm_gate_empty_repos() {
+        let workspace = tempfile::tempdir().unwrap();
+        let direnv = FakeDirenv::install("echo '{}'").cache();
+        let git = GitCli::new(
+            Secret::test("fake"),
+            workspace.path().to_path_buf(),
+            direnv,
+            vec![],
+        );
+        let mut state = DutyState::default();
+
+        let summary = run_warm(&git, &mut state).await;
+
+        assert_eq!(summary, "no warm commands configured");
     }
 }

--- a/src/tools/git/git_cli.rs
+++ b/src/tools/git/git_cli.rs
@@ -141,24 +141,22 @@ impl GitCli {
         Ok(warm_command(&self.warm_commands, &nwo).map(str::to_string))
     }
 
-    /// Prepare and warm every repo in `warm_commands` — the spec 24
-    /// warm duty. Clones missing checkouts. Sequential and awaited on
-    /// purpose: two cold builds would contend for the same cores.
-    /// Returns a per-repo summary for the duty history log.
-    pub async fn warm_configured_repos(&self) -> String {
-        let nwos: Vec<String> = self.warm_commands.keys().cloned().collect();
-        if nwos.is_empty() {
-            return "no warm commands configured".into();
-        }
-        let mut lines = Vec::with_capacity(nwos.len());
-        for nwo in nwos {
-            let status = self.prepare_and_warm(&nwo).await;
-            lines.push(format!("{nwo}: {status}"));
-        }
-        lines.join("; ")
+    /// Repo keys (`owner/repo`) with a configured warm command.
+    pub fn warm_repos(&self) -> Vec<String> {
+        self.warm_commands.keys().cloned().collect()
     }
 
-    async fn prepare_and_warm(&self, nwo: &str) -> String {
+    /// Whether the checkout exists under `projects/<nwo>`.
+    pub fn checkout_exists(&self, nwo: &str) -> bool {
+        super::checkout::rel_path("projects", nwo)
+            .is_ok_and(|rel| self.workspace_root.join(rel).join(".git").exists())
+    }
+
+    /// Prepare and warm a single repo — clone if absent, provision the
+    /// devshell, run the configured warm command. Sequential and
+    /// awaited on purpose: two cold builds would contend for the same
+    /// cores. Returns a status string for the duty summary.
+    pub async fn prepare_and_warm(&self, nwo: &str) -> String {
         let rel = match super::checkout::rel_path("projects", nwo) {
             Ok(rel) => rel,
             Err(e) => return format!("bad repo path: {e}"),
@@ -425,13 +423,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn warm_configured_repos_warms_an_existing_checkout() {
+    async fn prepare_and_warm_warms_an_existing_checkout() {
         let fake = FakeDirenv::install("echo '{}'");
         let (git, dir) = workspace_with_checkout(fake.cache(), "touch .warmed");
 
-        let summary = git.warm_configured_repos().await;
+        let summary = git.prepare_and_warm("o/r").await;
 
-        assert_eq!(summary, "o/r: warm");
+        assert_eq!(summary, "warm");
         assert!(dir.join(".warmed").exists(), "warm command must have run");
         assert_eq!(
             git.warmer().ready(&dir).await,
@@ -440,11 +438,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn warm_configured_repos_reports_a_failing_command() {
+    async fn prepare_and_warm_reports_a_failing_command() {
         let fake = FakeDirenv::install("echo '{}'");
         let (git, dir) = workspace_with_checkout(fake.cache(), "exit 1");
 
-        assert_eq!(git.warm_configured_repos().await, "o/r: failed");
+        assert_eq!(git.prepare_and_warm("o/r").await, "failed");
         assert_eq!(
             git.warmer().ready(&dir).await,
             Some(crate::tools::warm::WarmOutcome::Failed)


### PR DESCRIPTION
## Summary

The warm duty re-warmed every configured repo on every scheduled tick, whether or not anything had changed. At 24h cadence this wasted cycles on unchanged repos; at higher cadence it risked contention with real work.

Each tick now probes each repo's remote HEAD via `ls-remote` and warms only repos whose HEAD moved past a per-repo cursor (`warm/<nwo>` in the state DB), or that have no cursor (enrollment) or no checkout. The cursor advances only on a successful warm, so a failed warm retries next tick.

## Changes

- **`src/duty/mod.rs`** — New `run_warm()` function replaces the direct `warm_configured_repos()` call. Per-repo `ls-remote` probe, cursor comparison, due-when logic (no cursor, no checkout, or HEAD moved), cursor advance on success only. Six new tests covering skip, warm-on-move, enrollment, missing-checkout, failure-no-advance, and empty-repos.
- **`src/tools/git/git_cli.rs`** — `warm_configured_repos()` replaced by `warm_repos()` (returns keys), `checkout_exists()` (checks `.git`), and public `prepare_and_warm()` (was private). Two existing tests renamed and updated.
- **`specs/03-tools.md`** — Requirement 4 widened from "Unconditional" to "Unconditional per invocation".
- **`specs/24-self-directed-work.md`** — Warm duty description updated with gating; two failure-mode entries added.
- **`README.md`** — Warm duty comment updated.

## Test fixture notes

The test fixture creates a non-bare repo with a commit, then `clone --bare` (avoids cross-device link errors from pushing to an empty bare repo). Sets `commit.gpgsign false` (test process inherits the bot's GPG config), creates a checkout with `.envrc` and a GitHub origin URL (so `origin_nwo` resolves), and leaks the workspace + FakeDirenv tempdir (so they outlive the helper).

Closes #39