### PR TITLE
Prepare checkout before prompt-duty dispatch

### DIFF
--- a/deploy/configuration.nix
+++ b/deploy/configuration.nix
@@ -167,9 +167,6 @@ in
             repo = "CumuloGlobal/lightning-node";
             prompt = ''
               Work the dependency queues of CumuloGlobal/lightning-node.
-              First ensure a checkout exists: run git_clone for
-              CumuloGlobal/lightning-node (idempotent if present) and
-              do all work in projects/CumuloGlobal/lightning-node.
               Read the "Vulnerability & Dependency Remediation"
               section of that checkout's AGENTS.md; both procedures
               below live there — follow them exactly.

--- a/specs/24-self-directed-work.md
+++ b/specs/24-self-directed-work.md
@@ -100,11 +100,15 @@ the same `state/` file as `last_run`: a cheap fetch-and-compare
 decides whether a turn runs, and each run sees only the delta — an
 idle repo costs two git commands. Without a gate the prompt runs
 unconditionally on schedule. The repo must be listed in `git.repositories`;
-the turn runs on the repo's work session; anything the prompt wants
-to raise goes through the proposal contract below, same caps. This
-stays inside the trust model because the operator authors the prompt
-and the schedule in config — it is operator-defined work on a timer,
-not model-created work.
+the turn runs on the repo's work session; the scheduler prepares a fresh
+checkout (clone, fetch, detach at origin/HEAD, clean, devshell) before
+the turn starts, same `execution_checkout::prepare` flow the issue
+channel uses, so the agent finds a working base and injected conventions.
+A clone failure falls back to a manual-clone note rather than leaving the
+turn to improvise. Anything the prompt wants to raise goes through the
+proposal contract below, same caps. This stays inside the trust model
+because the operator authors the prompt and the schedule in config — it
+is operator-defined work on a timer, not model-created work.
 
 **Built-in vs operator-defined — the line.** Code owns contracts,
 config owns intent. A duty is built-in when its gate or mechanical

--- a/src/channel/execution_checkout.rs
+++ b/src/channel/execution_checkout.rs
@@ -12,10 +12,10 @@ use crate::tools::git::GitCli;
 use crate::tools::git::checkout;
 
 /// Guidance when no fresh checkout could be prepared for the agent.
-pub(super) const CLONE_YOURSELF: &str = "Clone or update the repo yourself before branching.";
+pub(crate) const CLONE_YOURSELF: &str = "Clone or update the repo yourself before branching.";
 
 /// Describe a prepared checkout for the agent.
-pub(super) fn ready_note(rel: &str) -> String {
+pub(crate) fn ready_note(rel: &str) -> String {
     format!(
         "A fresh checkout at the default branch is ready at {rel} \
          (use working_dir: \"{rel}\"). Branch from there; do not clone."
@@ -23,7 +23,7 @@ pub(super) fn ready_note(rel: &str) -> String {
 }
 
 /// Workspace-relative checkout directory for `owner/repo`.
-pub(super) fn checkout_rel_path(nwo: &str) -> Result<String, ToolError> {
+pub(crate) fn checkout_rel_path(nwo: &str) -> Result<String, ToolError> {
     checkout::rel_path("projects", nwo)
 }
 
@@ -31,7 +31,7 @@ pub(super) fn checkout_rel_path(nwo: &str) -> Result<String, ToolError> {
 /// branch, and drop any leftover files.
 ///
 /// Returns the workspace-relative checkout path.
-pub(super) async fn prepare(git: &GitCli, nwo: &str) -> Result<String, ToolError> {
+pub(crate) async fn prepare(git: &GitCli, nwo: &str) -> Result<String, ToolError> {
     let rel = checkout_rel_path(nwo)?;
     let url = git.repo_url(nwo);
     prepare_at(git, &url, &rel).await?;

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -4,7 +4,7 @@
 //! Telegram bot, and the GitHub and Linear pollers. The daemon drives
 //! their loops; `dispatch` holds the shared input/reply vocabulary.
 
-mod execution_checkout;
+pub(crate) mod execution_checkout;
 pub(crate) mod github;
 pub(crate) mod github_issues;
 pub(crate) mod linear;

--- a/src/duty/mod.rs
+++ b/src/duty/mod.rs
@@ -21,6 +21,7 @@ use tracing::{error, info, warn};
 
 use crate::agent::AgentHandle;
 use crate::agent::envelope::ChannelSource;
+use crate::channel::execution_checkout;
 use crate::clients::github::GithubClient;
 use crate::tools::git::GitCli;
 use schedule::Schedule;
@@ -260,6 +261,23 @@ async fn run_one(duty: &Duty, ctx: &RunCtx<'_>, state: &mut DutyState) {
     state.save(&ctx.state_db);
 }
 
+/// Prepare a fresh checkout for a prompt-duty turn, or advise a
+/// manual clone on failure. Mirrors `checkout_note` in
+/// `src/channel/github_issues.rs`.
+async fn checkout_note(duty: &Duty, git: Option<&GitCli>, repo: &str) -> String {
+    let Some(git) = git else {
+        warn!(duty = %duty.name, "no GitCli for prompt duty; agent must clone");
+        return execution_checkout::CLONE_YOURSELF.into();
+    };
+    match execution_checkout::prepare(git, repo).await {
+        Ok(rel) => execution_checkout::ready_note(&rel),
+        Err(e) => {
+            warn!(duty = %duty.name, "duty checkout prep failed: {e}");
+            execution_checkout::CLONE_YOURSELF.into()
+        }
+    }
+}
+
 /// Gate-check and send one dispatch duty through the actor. The
 /// outcome is journaled by the actor (unattended turn), not here.
 async fn dispatch(
@@ -277,6 +295,15 @@ async fn dispatch(
     };
     let Some((input, new_cursor)) = dispatch else {
         return;
+    };
+    // Prepare the repo checkout before the turn starts, so the agent
+    // finds a fresh base and injected conventions. Only prompt duties
+    // reach dispatch with session_hint = Some(repo); distill has None.
+    // Self-analysis has its own dispatch path (run_self_analysis) and
+    // targets the bot's own repo, which is always checked out.
+    let input = match session_hint.as_deref() {
+        Some(repo) => format!("{}\n\n{}", input, checkout_note(duty, git, repo).await),
+        None => input,
     };
     let cancel = CancellationToken::new();
     match handle
@@ -770,5 +797,107 @@ mod tests {
         let summary = run_warm(&git, &mut state).await;
 
         assert_eq!(summary, "no warm commands configured");
+    }
+
+    // --- checkout_note tests ---
+
+    /// A bare repo at `<workspace>/o/r.git` with one commit, and a
+    /// `GitCli` whose `clone_base` points at the workspace root via
+    /// `file://` so `repo_url("o/r")` resolves to the bare repo. No
+    /// pre-existing checkout — `prepare` clones from scratch.
+    fn checkout_test_setup() -> (GitCli, std::path::PathBuf) {
+        let workspace = tempfile::tempdir().unwrap();
+        let ws = workspace.path().to_path_buf();
+
+        let src = ws.join("o/r-src");
+        std::fs::create_dir_all(&src).unwrap();
+        git_cmd(&["init", src.to_str().unwrap()], &ws);
+        for (k, v) in [
+            ("user.email", "t@t"),
+            ("user.name", "t"),
+            ("commit.gpgsign", "false"),
+        ] {
+            git_cmd(&["config", k, v], &src);
+        }
+        std::fs::write(src.join("README"), "init").unwrap();
+        git_cmd(&["add", "."], &src);
+        git_cmd(&["commit", "-m", "init"], &src);
+
+        let bare = ws.join("o/r.git");
+        git_cmd(
+            &[
+                "clone",
+                "--bare",
+                src.to_str().unwrap(),
+                bare.to_str().unwrap(),
+            ],
+            &ws,
+        );
+
+        let direnv = FakeDirenv::install("echo '{}'");
+        let direnv_cache = direnv.cache();
+        std::mem::forget(direnv);
+        let git = GitCli::new(
+            Secret::test("fake"),
+            ws.clone(),
+            direnv_cache,
+            vec!["o/r".into()],
+        )
+        .with_clone_base(&format!("file://{}", ws.to_str().unwrap()));
+
+        let ws = workspace.keep();
+        (git, ws)
+    }
+
+    #[tokio::test]
+    async fn checkout_note_prepares_checkout() {
+        let (git, ws) = checkout_test_setup();
+        let duty = duty("test", Schedule::Every(3_600));
+
+        let note = checkout_note(&duty, Some(&git), "o/r").await;
+
+        assert!(
+            note.contains("A fresh checkout at the default branch is ready"),
+            "success must produce ready_note: {note}"
+        );
+        assert!(
+            ws.join("projects/o/r/.git").is_dir(),
+            "checkout must exist after prepare"
+        );
+    }
+
+    #[tokio::test]
+    async fn checkout_note_returns_clone_yourself_without_git() {
+        let duty = duty("test", Schedule::Every(3_600));
+
+        let note = checkout_note(&duty, None, "o/r").await;
+
+        assert_eq!(
+            note,
+            execution_checkout::CLONE_YOURSELF,
+            "no GitCli must fall back to CLONE_YOURSELF"
+        );
+    }
+
+    #[tokio::test]
+    async fn checkout_note_returns_clone_yourself_on_failure() {
+        let workspace = tempfile::tempdir().unwrap();
+        let direnv = FakeDirenv::install("echo '{}'").cache();
+        let git = GitCli::new(
+            Secret::test("fake"),
+            workspace.path().to_path_buf(),
+            direnv,
+            vec!["o/r".into()],
+        )
+        .with_clone_base("file:///nonexistent");
+        let duty = duty("test", Schedule::Every(3_600));
+
+        let note = checkout_note(&duty, Some(&git), "o/r").await;
+
+        assert_eq!(
+            note,
+            execution_checkout::CLONE_YOURSELF,
+            "clone failure must fall back to CLONE_YOURSELF: {note}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Prompt duties dispatched their turn with no checkout preparation, so a duty targeting a repo with no checkout sent the agent a turn with no repo, no conventions, and no toolchain. The issue and Linear channels already call `execution_checkout::prepare` before dispatch; the duty path skipped it.

## Changes

1. **Widen `execution_checkout` visibility to `pub(crate)`** — the module and its four public items were `pub(super)`, visible only within `src/channel/`. Widened so `src/duty/` can reach them.

2. **Wire checkout preparation into prompt-duty dispatch** — in `duty::dispatch`, when `session_hint` is `Some(repo)`, call `execution_checkout::prepare` (clone, fetch, detach at origin/HEAD, clean, devshell) and prepend the `ready_note` to the input. On failure or missing `GitCli`, fall back to `CLONE_YOURSELF` so the agent can still attempt a manual clone. Remove the now-redundant "run git_clone" workaround from the deploy config prompt text. Update spec 24.

## Acceptance criteria

- ✅ A prompt duty whose repo has no checkout clones it before the turn starts; the turn sees the repo's AGENTS.md conventions.
- ✅ Clone failure is reported as the duty outcome (CLONE_YOURSELF note + warn log), not discovered mid-turn.
- ✅ The workaround in the deploy config is removed.

Closes #40