### PR TITLE
Detect silent devshell evaluation failure in direnv

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -459,14 +459,21 @@ parallel tool calls each trigger a full `nix print-dev-env` evaluation.
    with a short TTL (60s) so repeated operations during a hang degrade
    to no-devshell immediately instead of each blocking for the full
    timeout
-4. **Graceful degradation** — if direnv fails, exec runs without the devshell
-5. **Warm on clone** — `git_clone` pre-populates the cache in the background
-6. **Trust before evaluate** — `git_clone` runs `direnv allow` synchronously
+4. **Detect silent flake failures** — `direnv export json` exits 0
+   even when `use flake` fails, printing the nix error to stderr and
+   exporting a bare environment. The cache checks stderr for nix's
+   `error:` marker (after stripping ANSI color codes) and treats a
+   match as a failure carrying the stderr, so the real error surfaces
+   in the duty outcome rather than as a `command not found` from bare
+   PATH.
+5. **Graceful degradation** — if direnv fails, exec runs without the devshell
+6. **Warm on clone** — `git_clone` pre-populates the cache in the background
+7. **Trust before evaluate** — `git_clone` runs `direnv allow` synchronously
    before returning, and only for repos listed in `git.repositories`. An
    `.envrc` is arbitrary shell executing at clone time, before anyone has
    read the repo; the allowlist is the only gate on that. Unlisted repos
-   clone normally and degrade to no-devshell (requirement 4).
-7. **Shared across tools** — single cache instance shared between exec and
+   clone normally and degrade to no-devshell (requirement 5).
+8. **Shared across tools** — single cache instance shared between exec and
    git_clone
 
 ### Invalidation
@@ -488,8 +495,8 @@ visible rather than inside a tool call.
 ### Requirements
 
 1. **Warm after the devshell** — the check command resolves from the
-   devshell, so it runs after [Direnv Cache](#direnv-cache) requirement 5
-   completes for that checkout
+   devshell, so it runs after [Direnv Cache](#direnv-cache) "Warm on
+   clone" completes for that checkout
 2. **Declared, not guessed** — command configured per repo (the repo's
    `AGENTS.md` states it in prose, not machine-readably). Unconfigured
    repos warm the devshell only

--- a/src/tools/direnv.rs
+++ b/src/tools/direnv.rs
@@ -282,6 +282,49 @@ impl DirenvCache {
     }
 }
 
+/// Check whether stderr contains a nix error marker. Nix prints errors
+/// as lines starting with `error:`; ANSI color codes are stripped first
+/// so colored output does not defeat the match. Direnv's own log
+/// messages start with `direnv:` and never trigger this.
+fn has_nix_error(stderr: &str) -> bool {
+    stderr.lines().any(line_starts_with_error)
+}
+
+/// Whether a line, after stripping ANSI escape sequences and leading
+/// whitespace, starts with `error:`. Nix's error marker is `error:` at
+/// the start of a line; direnv's log messages start with `direnv:`.
+fn line_starts_with_error(line: &str) -> bool {
+    let target = b"error:";
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    let mut ti = 0;
+    while i < bytes.len() && ti < target.len() {
+        // Skip ANSI CSI sequences: ESC [ ... (0x40..=0x7e).
+        if i + 1 < bytes.len() && bytes[i] == 0x1b && bytes[i + 1] == b'[' {
+            i += 2;
+            while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
+                i += 1;
+            }
+            if i < bytes.len() {
+                i += 1;
+            }
+            continue;
+        }
+        // Skip leading whitespace before the target.
+        if ti == 0 && bytes[i].is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        if bytes[i] == target[ti] {
+            i += 1;
+            ti += 1;
+        } else {
+            return false;
+        }
+    }
+    ti == target.len()
+}
+
 /// Run `direnv export json` and parse the result.
 async fn evaluate_direnv(
     binary: &'static str,
@@ -317,6 +360,18 @@ async fn evaluate_direnv(
         return Err(DirenvError::Failed(format!(
             "direnv export json exited {}: {stderr}",
             output.exit_code,
+        )));
+    }
+
+    // direnv swallows `use flake` failures: it exits 0, prints the nix
+    // error to stderr, and exports a bare environment. Detect this by
+    // checking for nix's `error:` marker on stderr (after stripping ANSI
+    // color codes). On success stderr carries only direnv log messages
+    // (prefixed `direnv:`), which never start with `error:`.
+    let stderr = output.stderr.trim();
+    if has_nix_error(stderr) {
+        return Err(DirenvError::Failed(format!(
+            "direnv export json reported an error: {stderr}"
         )));
     }
 
@@ -601,6 +656,96 @@ mod tests {
                 .count(),
             2,
             "fingerprint change must re-evaluate despite cached timeout",
+        );
+    }
+
+    // ── Silent failure detection ───────────────────────────────────
+
+    #[test]
+    fn line_starts_with_error_plain() {
+        assert!(line_starts_with_error("error: Failed to fetch"));
+    }
+
+    #[test]
+    fn line_starts_with_error_ansi_colored() {
+        assert!(line_starts_with_error(
+            "\x1b[31;1merror:\x1b[0m Failed to fetch"
+        ));
+    }
+
+    #[test]
+    fn line_starts_with_error_leading_whitespace() {
+        assert!(line_starts_with_error("  error: something"));
+    }
+
+    #[test]
+    fn line_starts_with_error_ansi_then_whitespace() {
+        assert!(line_starts_with_error("\x1b[0m  error: something"));
+    }
+
+    #[test]
+    fn line_does_not_match_direnv_log() {
+        assert!(!line_starts_with_error("direnv: loading flake"));
+        assert!(!line_starts_with_error("direnv: export GEM_HOME"));
+    }
+
+    #[test]
+    fn line_does_not_match_indented_error() {
+        assert!(!line_starts_with_error("  some context: error: nested"));
+    }
+
+    #[test]
+    fn line_does_not_match_empty() {
+        assert!(!line_starts_with_error(""));
+    }
+
+    #[test]
+    fn has_nix_error_detects_in_multiline_stderr() {
+        let stderr = "direnv: loading flake\nerror: Failed to fetch git repository\n";
+        assert!(has_nix_error(stderr));
+    }
+
+    #[test]
+    fn has_nix_error_false_on_direnv_logs_only() {
+        let stderr = "direnv: loading flake\ndirenv: export PATH\n";
+        assert!(!has_nix_error(stderr));
+    }
+
+    #[tokio::test]
+    async fn cache_detects_silent_flake_failure() {
+        // Simulate direnv exit 0 with a nix error on stderr and an
+        // empty JSON export — the real-world `use flake` failure.
+        let fake =
+            FakeDirenv::install("echo 'error: Failed to fetch git repository' >&2\necho '{}'");
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".envrc"), "use flake").unwrap();
+
+        let cache = fake.cache();
+        let err = cache.get(dir.path()).await.unwrap_err();
+        assert!(
+            matches!(&err, DirenvError::Failed(m) if m.contains("Failed to fetch")),
+            "silent flake failure must surface as Failed with stderr: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_succeeds_with_direnv_logs_on_stderr() {
+        // Simulate direnv exit 0 with log messages on stderr and a
+        // valid JSON export — normal successful operation.
+        let fake = FakeDirenv::install(
+            "echo 'direnv: loading flake' >&2\necho 'direnv: export PATH' >&2\necho '{\"PATH\": \"/nix/store/bin\"}'",
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".envrc"), "use flake").unwrap();
+
+        let cache = fake.cache();
+        let env = cache.get(dir.path()).await.unwrap().unwrap();
+        assert_eq!(
+            env.get("PATH").map(String::as_str),
+            Some("/nix/store/bin"),
+            "direnv log messages on stderr must not cause a false failure"
         );
     }
 }


### PR DESCRIPTION
## Summary

`direnv export json` exits 0 even when `use flake` fails inside `.envrc` — it prints the nix error to stderr and exports a bare environment. The cache treated exit 0 as success, discarded stderr, and the failure surfaced three steps later as `just: command not found` (exit 127). The real nix error never appeared in any log.

## Change

After the exit-code-0 path in `evaluate_direnv`, check stderr for nix's `error:` marker (after stripping ANSI color codes). On success, stderr carries only direnv log messages (prefixed `direnv:`), which never start with `error:`. A match returns `DirenvError::Failed` carrying the stderr, so the real error propagates through `provision_devshell` into the duty outcome as `"skipped: devshell eval failed: direnv export json reported an error: error: Failed to fetch..."`.

The existing not-cached semantics for `Failed` ensure the next caller retries.

## Acceptance criteria

- ✅ A repo whose devshell cannot evaluate produces a warm/duty outcome naming the underlying nix error (the stderr), not a command-not-found from bare PATH.
- ✅ The failed evaluation is not cached (already true for `DirenvError::Failed`).
- ✅ The stderr is preserved in the error (and thus in the warn log entry).

Closes #41