### PR TITLE
Enforce output ceiling on GitHub log and API downloads

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -92,11 +92,11 @@ hardcoded, so typos are caught by tests instead.
   Context-size limits live in the engines (`context.tool_output_tokens`,
   spec 14), which externalize or truncate tool results long before the
   ceiling matters.
-- **`truncate_tail`** — Tail-keeping variant for log-shaped output where
-  the diagnosis concentrates at the end. Keeps the last `max_bytes` and
-  prepends `[truncated N leading bytes]`. Used by `job_logs` (CI logs);
-  `github_api`'s raw path uses head-keeping `truncate_output` (generic
-  API responses are not tail-weighted).
+- **`truncate_head`** — Head-truncating variant for log-shaped output where
+  the diagnosis concentrates at the end. Drops leading bytes and keeps
+  the last `max_bytes`, prepending `[truncated N leading bytes]`. Used
+  by `job_logs` (CI logs); `github_api`'s raw path uses head-keeping
+  `truncate_output` (generic API responses are not tail-weighted).
 - **`PathGuard`** — workspace-confined path resolution. Rejects null bytes,
   `../`, and absolute paths. Canonicalizes and verifies the result is under the
   workspace root. Provides `resolve()` for existing files and `resolve_new()`

--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -92,6 +92,11 @@ hardcoded, so typos are caught by tests instead.
   Context-size limits live in the engines (`context.tool_output_tokens`,
   spec 14), which externalize or truncate tool results long before the
   ceiling matters.
+- **`truncate_tail`** — Tail-keeping variant for log-shaped output where
+  the diagnosis concentrates at the end. Keeps the last `max_bytes` and
+  prepends `[truncated N leading bytes]`. Used by `job_logs` (CI logs);
+  `github_api`'s raw path uses head-keeping `truncate_output` (generic
+  API responses are not tail-weighted).
 - **`PathGuard`** — workspace-confined path resolution. Rejects null bytes,
   `../`, and absolute paths. Canonicalizes and verifies the result is under the
   workspace root. Provides `resolve()` for existing files and `resolve_new()`

--- a/src/clients/github.rs
+++ b/src/clients/github.rs
@@ -321,7 +321,7 @@ impl GithubClient {
     }
 
     /// Raw log text of a job. GitHub answers with a redirect to a
-    /// blob URL, which reqwest follows. Tail-truncated to the
+    /// blob URL, which reqwest follows. Head-truncated to the
     /// tool-output ceiling before returning (CI logs are tail-weighted).
     pub async fn job_logs(&self, nwo: &str, job_id: u64) -> Result<String, GithubError> {
         let raw = (self.request)(
@@ -338,7 +338,7 @@ impl GithubClient {
         }
         let text = String::from_utf8_lossy(&raw.body);
         Ok(
-            crate::tools::truncate_tail(&text, crate::tools::TOOL_OUTPUT_CEILING_BYTES)
+            crate::tools::truncate_head(&text, crate::tools::TOOL_OUTPUT_CEILING_BYTES)
                 .into_owned(),
         )
     }

--- a/src/clients/github.rs
+++ b/src/clients/github.rs
@@ -321,7 +321,8 @@ impl GithubClient {
     }
 
     /// Raw log text of a job. GitHub answers with a redirect to a
-    /// blob URL, which reqwest follows.
+    /// blob URL, which reqwest follows. Tail-truncated to the
+    /// tool-output ceiling before returning (CI logs are tail-weighted).
     pub async fn job_logs(&self, nwo: &str, job_id: u64) -> Result<String, GithubError> {
         let raw = (self.request)(
             "GET",
@@ -335,7 +336,11 @@ impl GithubClient {
                 body: String::from_utf8_lossy(&raw.body).into_owned(),
             });
         }
-        Ok(String::from_utf8_lossy(&raw.body).into_owned())
+        let text = String::from_utf8_lossy(&raw.body);
+        Ok(
+            crate::tools::truncate_tail(&text, crate::tools::TOOL_OUTPUT_CEILING_BYTES)
+                .into_owned(),
+        )
     }
 }
 

--- a/src/tools/github/api.rs
+++ b/src/tools/github/api.rs
@@ -151,7 +151,10 @@ impl Api {
         if text.trim().is_empty() {
             return Ok(format!("OK ({})", raw.status));
         }
-        Ok(text.into_owned())
+        Ok(
+            crate::tools::truncate_output(&text, crate::tools::TOOL_OUTPUT_CEILING_BYTES)
+                .into_owned(),
+        )
     }
 }
 

--- a/src/tools/github/ci_status.rs
+++ b/src/tools/github/ci_status.rs
@@ -162,4 +162,43 @@ Step failed"
         let out = tool.run("projects/r", None).await.unwrap();
         assert_eq!(out, "No failed runs on branch `work`.");
     }
+
+    /// A log exceeding the ceiling is tail-truncated: the output ends
+    /// with the log's final lines (the diagnosis), not its first ones.
+    #[tokio::test]
+    async fn oversized_log_keeps_tail() {
+        let ceiling = crate::tools::TOOL_OUTPUT_CEILING_BYTES;
+        let setup = "x".repeat(ceiling * 2);
+        let diagnosis = "error: the diagnosis is at the end\n";
+        let full_log = format!("{setup}{diagnosis}");
+        let api = stub_api_with_repo("owner/repo", move |_method, path, _body| {
+            if path.starts_with("repos/owner/repo/actions/runs?") {
+                return br#"{"workflow_runs":[{"id":7,"display_title":"CI",
+                    "name":"test","created_at":"2025-01-15T10:00:00Z",
+                    "html_url":"https://example.invalid/7"}]}"#
+                    .to_vec();
+            }
+            if path.ends_with("/jobs?per_page=100") {
+                return br#"{"jobs":[
+                    {"id":1,"name":"build","conclusion":"failure"}]}"#
+                    .to_vec();
+            }
+            assert!(path.ends_with("/logs"));
+            full_log.as_bytes().to_vec()
+        });
+        let tool = CiStatus(api);
+        let out = tool.run("projects/r", None).await.unwrap();
+        // The output ends with the diagnosis (tail kept).
+        assert!(
+            out.ends_with(diagnosis),
+            "output should end with the diagnosis"
+        );
+        // The output starts with the truncation header (head dropped).
+        assert!(out.contains("[truncated "), "truncation header missing");
+        // The very first bytes of the log are gone (head was dropped).
+        assert!(
+            !out.starts_with('x'),
+            "head of the log should have been truncated"
+        );
+    }
 }

--- a/src/tools/github/test_helpers.rs
+++ b/src/tools/github/test_helpers.rs
@@ -22,7 +22,14 @@ where
         vec!["commit", "--allow-empty", "-m", "seed"],
     ] {
         let out = std::process::Command::new("git")
-            .args(["-c", "user.email=t@example.com", "-c", "user.name=t"])
+            .args([
+                "-c",
+                "user.email=t@example.com",
+                "-c",
+                "user.name=t",
+                "-c",
+                "commit.gpgsign=false",
+            ])
             .args(&args)
             .current_dir(&repo)
             .output()

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -389,6 +389,23 @@ pub(crate) fn truncate_output(s: &str, max_bytes: usize) -> Cow<'_, str> {
     }
 }
 
+/// Tail-keeping truncation for log-shaped output, where the diagnosis
+/// concentrates at the end. Keeps the last `max_bytes` and prepends a
+/// header naming the dropped leading byte count.
+pub(crate) fn truncate_tail(s: &str, max_bytes: usize) -> Cow<'_, str> {
+    if s.len() <= max_bytes {
+        Cow::Borrowed(s)
+    } else {
+        let start = s.len() - max_bytes;
+        let start = s.ceil_char_boundary(start);
+        Cow::Owned(format!(
+            "[truncated {} leading bytes]\n{}",
+            start,
+            &s[start..]
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -489,6 +506,39 @@ mod tests {
         // '€' is 3 bytes. Truncating at byte 2 should cut back to 0.
         let result = truncate_output("€", 2);
         assert!(result.starts_with("...\n[truncated 3 bytes]"));
+    }
+
+    #[test]
+    fn truncate_tail_short_string_borrowed() {
+        assert!(matches!(
+            truncate_tail("hello", 100),
+            Cow::Borrowed("hello")
+        ));
+    }
+
+    #[test]
+    fn truncate_tail_exact_length_borrowed() {
+        assert!(matches!(truncate_tail("hello", 5), Cow::Borrowed("hello")));
+    }
+
+    #[test]
+    fn truncate_tail_keeps_end() {
+        let long = "header_".to_string() + &"a".repeat(100);
+        let result = truncate_tail(&long, 10);
+        assert!(result.starts_with("[truncated "));
+        assert!(result.contains(" leading bytes]"));
+        // The tail is the last 10 bytes of the string.
+        assert!(result.ends_with(&long[long.len() - 10..]));
+    }
+
+    #[test]
+    fn truncate_tail_utf8_boundary() {
+        // "€€" is 6 bytes. Keeping 4 bytes means start=2, which is
+        // mid-character. ceil_char_boundary rounds to 3, so we keep
+        // the second '€' (3 bytes) instead of splitting the first.
+        let result = truncate_tail("€€", 4);
+        assert!(result.starts_with("[truncated 3 leading bytes]"));
+        assert!(result.contains('€'));
     }
 
     #[tokio::test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -389,10 +389,10 @@ pub(crate) fn truncate_output(s: &str, max_bytes: usize) -> Cow<'_, str> {
     }
 }
 
-/// Tail-keeping truncation for log-shaped output, where the diagnosis
-/// concentrates at the end. Keeps the last `max_bytes` and prepends a
-/// header naming the dropped leading byte count.
-pub(crate) fn truncate_tail(s: &str, max_bytes: usize) -> Cow<'_, str> {
+/// Head-truncating variant for log-shaped output, where the diagnosis
+/// concentrates at the end. Drops leading bytes and keeps the last
+/// `max_bytes`, prepending a header naming the dropped count.
+pub(crate) fn truncate_head(s: &str, max_bytes: usize) -> Cow<'_, str> {
     if s.len() <= max_bytes {
         Cow::Borrowed(s)
     } else {
@@ -509,22 +509,22 @@ mod tests {
     }
 
     #[test]
-    fn truncate_tail_short_string_borrowed() {
+    fn truncate_head_short_string_borrowed() {
         assert!(matches!(
-            truncate_tail("hello", 100),
+            truncate_head("hello", 100),
             Cow::Borrowed("hello")
         ));
     }
 
     #[test]
-    fn truncate_tail_exact_length_borrowed() {
-        assert!(matches!(truncate_tail("hello", 5), Cow::Borrowed("hello")));
+    fn truncate_head_exact_length_borrowed() {
+        assert!(matches!(truncate_head("hello", 5), Cow::Borrowed("hello")));
     }
 
     #[test]
-    fn truncate_tail_keeps_end() {
+    fn truncate_head_keeps_end() {
         let long = "header_".to_string() + &"a".repeat(100);
-        let result = truncate_tail(&long, 10);
+        let result = truncate_head(&long, 10);
         assert!(result.starts_with("[truncated "));
         assert!(result.contains(" leading bytes]"));
         // The tail is the last 10 bytes of the string.
@@ -532,11 +532,11 @@ mod tests {
     }
 
     #[test]
-    fn truncate_tail_utf8_boundary() {
+    fn truncate_head_utf8_boundary() {
         // "€€" is 6 bytes. Keeping 4 bytes means start=2, which is
         // mid-character. ceil_char_boundary rounds to 3, so we keep
         // the second '€' (3 bytes) instead of splitting the first.
-        let result = truncate_tail("€€", 4);
+        let result = truncate_head("€€", 4);
         assert!(result.starts_with("[truncated 3 leading bytes]"));
         assert!(result.contains('€'));
     }


### PR DESCRIPTION
## Summary

`TOOL_OUTPUT_CEILING_BYTES` protects the daemon from runaway output filling RAM, enforced in `cli_runner`, `exec`, and `grep` — but not in the GitHub client. `job_logs` returned the raw HTTP body unbounded, and `github_ci_status` concatenates one whole-job log per failed job. A pathological Actions log is exactly the runaway the ceiling exists for.

The existing `truncate_output` keeps the head and drops the tail — correct for command output but wrong for CI logs where the failure concentrates at the end.

## Changes

- **`truncate_tail`** (new, `src/tools/mod.rs`) — tail-keeping variant that keeps the last `max_bytes` and prepends `[truncated N leading bytes]`. UTF-8-safe via `ceil_char_boundary`.
- **`job_logs`** (`src/clients/github.rs`) — applies `truncate_tail` with the ceiling before returning (CI logs are tail-weighted).
- **`github_api` raw path** (`src/tools/github/api.rs`) — applies head-keeping `truncate_output` (generic API responses are not tail-weighted).
- **Test helper** (`src/tools/github/test_helpers.rs`) — disables GPG signing on the seed commit so async tests run in environments with `commit.gpgsign` enabled.
- **Spec** (`specs/03-tools.md`) — documents `truncate_tail` and which path uses which truncation direction.

## Test

`oversized_log_keeps_tail` feeds a 2×ceiling log through the full stubbed tool path and asserts the output ends with the diagnosis (tail kept), contains the truncation header, and dropped the head.

Closes #44