### PR TITLE
Drop author filter from self-analysis dedup query

### DIFF
--- a/specs/24-self-directed-work.md
+++ b/specs/24-self-directed-work.md
@@ -256,10 +256,10 @@ the tool result the model reads, which is a separate path.
   before dispatch (the bot is a normal account, so its filings are
   author-searchable — no marker label). At the cap the duty skips and
   journals the skip; triage frees the cap.
-- Duplicate suppression: the open bot-authored issues are injected
-  into the dispatch prompt (in-context dedup); duties with natural
-  evidence keys (CI triage) additionally embed them for mechanical
-  suppression.
+- Duplicate suppression: all open issues on the repo (regardless of
+  author) are injected into the dispatch prompt (in-context dedup), so
+  human-filed duplicates are caught too; duties with natural evidence
+  keys (CI triage) additionally embed them for mechanical suppression.
 - One filing per run, stated in the turn contract: a daily duty files
   at most ~7 a week against a cap of 3, so triage binds quickly.
 - No per-day token budget yet, deliberately: the schedule is the cost

--- a/src/duty/mod.rs
+++ b/src/duty/mod.rs
@@ -372,16 +372,20 @@ async fn run_self_analysis(
             return;
         }
     };
-    if proposals.len() >= self_analysis::PROPOSAL_CAP {
+    let bot_count = match bot_proposal_count(client, repo).await {
+        Ok(n) => n,
+        Err(e) => {
+            error!(duty = %duty.name, "bot-proposal count failed (will retry next period): {e}");
+            return;
+        }
+    };
+    if bot_count >= self_analysis::PROPOSAL_CAP {
         // The delta stays unconsumed: triage frees the cap, and the
         // next run sees the accumulated material.
         record(
             journal_path,
             &duty.name,
-            &format!(
-                "skipped: proposal cap reached ({} open on {repo})",
-                proposals.len(),
-            ),
+            &format!("skipped: proposal cap reached ({bot_count} bot-authored on {repo})"),
         );
         return;
     }
@@ -408,20 +412,34 @@ async fn run_self_analysis(
     }
 }
 
-/// Titles of open issues the bot already filed on `repo`, `#N title`
-/// formatted for prompt injection.
+/// Titles of all open issues on `repo`, `#N title` formatted for
+/// prompt injection. Includes issues filed by anyone so the dedup
+/// set catches human-filed duplicates too.
 async fn open_proposals(
     client: &GithubClient,
     repo: &str,
 ) -> Result<Vec<String>, crate::error::GithubError> {
-    let login = client.user().await?.login;
     let issues = client
-        .search_issues(&format!("is:issue is:open author:{login} repo:{repo}"))
+        .search_issues(&format!("is:issue is:open repo:{repo}"))
         .await?;
     Ok(issues
         .iter()
         .map(|i| format!("#{} {}", i.number, i.title))
         .collect())
+}
+
+/// Count of open issues the bot itself authored on `repo`. The
+/// proposal cap counts only bot-authored filings, not every open
+/// issue on the repo.
+async fn bot_proposal_count(
+    client: &GithubClient,
+    repo: &str,
+) -> Result<usize, crate::error::GithubError> {
+    let login = client.user().await?.login;
+    let issues = client
+        .search_issues(&format!("is:issue is:open author:{login} repo:{repo}"))
+        .await?;
+    Ok(issues.len())
 }
 
 /// Probe the new-commits gate. Returns the dispatch input and the
@@ -514,6 +532,7 @@ async fn run_warm(git: &GitCli, state: &mut DutyState) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::clients::RawResponse;
 
     fn duty(name: &str, schedule: Schedule) -> Duty {
         Duty {
@@ -899,5 +918,67 @@ mod tests {
             execution_checkout::CLONE_YOURSELF,
             "clone failure must fall back to CLONE_YOURSELF: {note}"
         );
+    }
+
+    #[tokio::test]
+    async fn open_proposals_queries_all_open_issues_not_bot_authored_only() {
+        let client = GithubClient::from_fn(|method, path, _body| async move {
+            assert_eq!(method, "GET");
+            // No author: qualifier — dedup must see human-filed issues too.
+            assert!(
+                !path.contains("author:"),
+                "query must not filter by author: {path}"
+            );
+            assert!(path.contains("is:issue+is:open+repo:owner/repo"));
+            Ok(RawResponse {
+                status: 200,
+                body: br#"{"items":[
+                    {"number":49,"title":"file_edit no-match error dumps entire file content unbounded",
+                     "user":{"login":"amackillop"},
+                     "repository_url":"https://api.github.com/repos/owner/repo",
+                     "updated_at":"2026-08-14T10:00:00Z","labels":[]},
+                    {"number":60,"title":"file_edit no-match error dumps entire file content unbounded",
+                     "user":{"login":"kitaebot"},
+                     "repository_url":"https://api.github.com/repos/owner/repo",
+                     "updated_at":"2026-08-14T11:00:00Z","labels":[]}
+                ]}"#
+                .to_vec(),
+            })
+        });
+        let proposals = open_proposals(&client, "owner/repo").await.unwrap();
+        assert_eq!(proposals.len(), 2);
+        assert!(proposals[0].contains("#49"));
+        assert!(proposals[1].contains("#60"));
+    }
+
+    #[tokio::test]
+    async fn bot_proposal_count_filters_by_bot_author() {
+        let client = GithubClient::from_fn(|method, path, _body| async move {
+            assert_eq!(method, "GET");
+            if path == "user" {
+                return Ok(RawResponse {
+                    status: 200,
+                    body: br#"{"login":"kitaebot"}"#.to_vec(),
+                });
+            }
+            // Must filter by author: — the cap counts only bot-authored.
+            assert!(
+                path.contains("author:"),
+                "cap query must filter by author: {path}"
+            );
+            assert!(path.contains("is:issue+is:open+author:kitaebot+repo:owner/repo"));
+            Ok(RawResponse {
+                status: 200,
+                body: br#"{"items":[
+                    {"number":60,"title":"file_edit no-match error dumps entire file content unbounded",
+                     "user":{"login":"kitaebot"},
+                     "repository_url":"https://api.github.com/repos/owner/repo",
+                     "updated_at":"2026-08-14T11:00:00Z","labels":[]}
+                ]}"#
+                .to_vec(),
+            })
+        });
+        let count = bot_proposal_count(&client, "owner/repo").await.unwrap();
+        assert_eq!(count, 1);
     }
 }

--- a/src/duty/self_analysis.rs
+++ b/src/duty/self_analysis.rs
@@ -198,8 +198,8 @@ fn error_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
     Ok(files)
 }
 
-/// The dispatch prompt: symptoms, already-filed proposals, and the
-/// one-proposal contract.
+/// The dispatch prompt: symptoms, open issues on the repo for
+/// dedup, and the one-proposal contract.
 pub fn format_prompt(repo: &str, delta: &Delta, open_proposals: &[String]) -> String {
     use std::fmt::Write;
     let mut s = String::from(
@@ -224,8 +224,8 @@ pub fn format_prompt(repo: &str, delta: &Delta, open_proposals: &[String]) -> St
     if !open_proposals.is_empty() {
         let _ = write!(
             s,
-            "\nProposals you already filed, still open — do not re-file \
-             these or variants of them:\n",
+            "\nOpen issues on this repo — if your symptom matches one \
+             (yours or human-filed), do not file; cite it instead:\n",
         );
         for title in open_proposals {
             let _ = writeln!(s, "- {title}");


### PR DESCRIPTION
## Summary

`open_proposals` queried `is:issue is:open author:{login}`, so the self-analysis dedup set only contained bot-authored issues. Human-filed issues were invisible, causing #60 to duplicate #49 (a human-filed issue reporting the same defect).

## Changes

- **`open_proposals`** (`src/duty/mod.rs`): drop the `author:{login}` qualifier so the dedup set is all open issues on the repo, regardless of who filed them.
- **`bot_proposal_count`** (`src/duty/mod.rs`): new function extracted from the old `open_proposals` for the proposal cap check, which must count only bot-authored filings. The cap semantics are unchanged — a repo with many human-filed open issues won't stall the duty.
- **`format_prompt`** (`src/duty/self_analysis.rs`): reword the dedup list header from "Proposals you already filed" to "Open issues on this repo — if your symptom matches one (yours or human-filed), do not file; cite it instead" so the model recognizes human-filed duplicates.
- **Spec 24**: updated the duplicate suppression description to match.

## Tests

Two new tests:
- `open_proposals_queries_all_open_issues_not_bot_authored_only` — verifies no `author:` qualifier in the dedup query.
- `bot_proposal_count_filters_by_bot_author` — verifies the cap query keeps the `author:` filter.

Closes #61