### PR TITLE
Bound file_edit mismatch errors in tool result and log

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -287,11 +287,21 @@ without a follow-up read and gets line anchors for subsequent edits.
 For `replace_all`, the match count plus the first edited region.
 
 **Stale-read failure**: when no rung matches, the error carries a hint
-that the file may have changed since it was read, followed by the
-file's current content. Recovery becomes a same-turn re-issue of the
-edit against fresh content instead of a read round-trip. The snapshot
-is not truncated at the tool layer; it rides the standard tool-output
-pipeline, where the engines own size policy.
+that the file may have changed since it was read, followed by a
+bounded excerpt around the nearest candidate line — the line with the
+highest normalized-token overlap with `old_string` (ties to the
+earliest; zero overlap anchors at the top) — in `file_read`'s numbered
+format with three lines of context each side and a `[showing lines
+X-Y of Z]` header when the window is partial. The excerpt is capped at
+2 KiB by the tool itself (`truncate_output`), not delegated to the
+engine: the same string is the log line and error-tee entry, and the
+tee has no per-entry cap (spec 24, "entry size is correctness"). An
+excerpt around the nearest match also beats a full dump for
+re-synchronization — the model gets line anchors near where it was
+editing instead of a wall of source to re-scan. Recovery remains a
+same-turn re-issue of the edit against the excerpt, or a targeted
+`file_read` when the excerpt shows the file moved further than one
+window.
 
 ---
 
@@ -596,9 +606,9 @@ for the shared target dir against the ~19 GB VM disk.
 | Malformed arguments | `InvalidArguments` | Error text returned to LLM |
 | Command on deny list | `Blocked { operation, guidance }` | Friendly message to LLM explaining what to use instead |
 | Exec timeout | `Timeout` | Process killed, error returned to LLM |
-| Tool runtime error | `ExecutionFailed` | Error text returned to LLM |
-| `file_edit` no match | `ExecutionFailed` | Error carries stale-read hint + current file content (see tool section) |
-| `file_edit` ambiguous match | `ExecutionFailed` | Error lists rung, count, and match line numbers |
+| Command exited non-zero | `CommandFailed` | Error text (command, output, exit code) returned to LLM |
+| `file_edit` no match | `Precondition` | Error carries stale-read hint + bounded excerpt around the nearest candidate line (see tool section) |
+| `file_edit` ambiguous match | `Precondition` | Error lists rung, count, and match line numbers |
 
 All errors are surfaced to the LLM as text. The LLM decides how to proceed.
 The agent loop's policy gate escalates repeated `Blocked` errors (see

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 use crate::tools::mcp::McpError;
+use crate::tools::truncate_output;
 
 /// Top-level agent error.
 #[derive(Debug, Error)]
@@ -288,7 +289,9 @@ pub enum ToolError {
     /// hold: an edit pattern that matches zero or many places, a
     /// missing working directory, a rate limit, a rewrite that
     /// changed the tree. The message is the whole story -- there is
-    /// no underlying error to keep.
+    /// no underlying error to keep. Messages must lead with the
+    /// operation and failure mode: the log rendering keeps only the
+    /// first 500 bytes (see `log_summary`).
     #[error("precondition failed: {0}")]
     Precondition(String),
 
@@ -390,16 +393,30 @@ impl ToolError {
             | Self::Linear(_)
             | Self::Mcp { .. }
             | Self::NotFound(_)
-            | Self::Precondition(_)
-            | Self::Spawn { .. }
             | Self::Sqlite { .. }
+            | Self::Spawn { .. }
             | Self::SubAgent { .. }
             | Self::Telegram(_)
             | Self::Timeout { .. }
             | Self::WebSearch(_) => self.to_string(),
+            // The message is the whole story, but it is also the
+            // model-facing payload: a file_edit no-match embeds a
+            // content excerpt, and other tools' messages carry
+            // arbitrary length. The model reads the whole thing in the
+            // tool result; the tee takes a bounded head, which keeps
+            // the operation and the failure mode and drops the
+            // payload (spec 24, entry size is correctness).
+            Self::Precondition(_) => {
+                truncate_output(&self.to_string(), PRECONDITION_LOG_MAX).into_owned()
+            }
         }
     }
 }
+
+/// Byte cap on a `Precondition` failure's log rendering. Generous
+/// against the structured variants (a path, a command, a URL) and
+/// cuts the payload-carrying ones (`file_edit`'s content excerpt).
+const PRECONDITION_LOG_MAX: usize = 500;
 
 /// Workspace initialization errors.
 #[derive(Debug, Error)]
@@ -586,6 +603,37 @@ mod tests {
     #[test]
     fn other_variants_summarize_as_themselves() {
         let e = ToolError::NotFound("nosuchtool".to_string());
+        assert_eq!(e.log_summary(), e.to_string());
+    }
+
+    /// A precondition's message is the model-facing payload (a
+    /// `file_edit` no-match embeds a content excerpt); the tee takes a
+    /// bounded head of it. The head keeps the operation and failure
+    /// mode, which lead the rendering.
+    #[test]
+    fn precondition_log_summary_is_capped() {
+        let e = ToolError::Precondition(format!(
+            "no match found for old_string in src/duty/mod.rs; the file may \
+             have changed since you read it. Nearest candidate:\n{}",
+            "filler\n".repeat(200)
+        ));
+        let summary = e.log_summary();
+        assert!(
+            summary.len() <= PRECONDITION_LOG_MAX + 64,
+            "{}",
+            summary.len()
+        );
+        assert!(
+            summary.starts_with("precondition failed: no match found"),
+            "{summary}"
+        );
+        assert!(summary.contains("[truncated"), "{summary}");
+    }
+
+    /// Short precondition messages — the common case — log whole.
+    #[test]
+    fn short_precondition_logs_whole() {
+        let e = ToolError::Precondition("ls-remote owner/repo: no HEAD in output".into());
         assert_eq!(e.log_summary(), e.to_string());
     }
 }

--- a/src/tools/file_edit.rs
+++ b/src/tools/file_edit.rs
@@ -5,6 +5,8 @@
 //! Unicode-folded. Rungs are ordered least- to most-aggressive; the
 //! first rung with at least one match decides the outcome.
 
+use std::cmp::Reverse;
+use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 
@@ -13,7 +15,7 @@ use serde::Deserialize;
 use tracing::debug;
 
 use super::path::PathGuard;
-use super::{Tool, ToolCtx};
+use super::{Tool, ToolCtx, truncate_output};
 use crate::error::ToolError;
 
 #[derive(Deserialize, JsonSchema)]
@@ -82,10 +84,10 @@ impl Tool for FileEdit {
             })?;
 
             let Some((rung, spans)) = find_matches(&content, &args.old_string) else {
-                return Err(ToolError::Precondition(format!(
-                    "no match found for old_string in {path}; the file may have \
-                     changed since you read it. Current content:\n{content}",
-                    path = args.path,
+                return Err(ToolError::Precondition(stale_read_message(
+                    &content,
+                    &args.old_string,
+                    &args.path,
                 )));
             };
 
@@ -229,6 +231,69 @@ fn ambiguous_message(rung: Rung, spans: &[Span], content: &str, path: &str) -> S
     )
 }
 
+/// Byte cap on the stale-read snapshot. The model needs enough to
+/// re-synchronize the edit, not the whole file; files that large are
+/// stubbed out of context by the engine anyway (spec 14).
+const SNAPSHOT_MAX_BYTES: usize = 2048;
+
+/// Error text for a no-match on every rung. Carries the stale-read
+/// hint plus a bounded excerpt around the closest candidate line, not
+/// the whole file: the whole-file embed drowned the error tee on large
+/// files (spec 24, entry size is correctness), and an excerpt around
+/// the nearest match beats a full dump for re-synchronization anyway.
+fn stale_read_message(content: &str, old: &str, path: &str) -> String {
+    let excerpt = match nearest_line(content, old) {
+        Some(line) => excerpt_around(content, line),
+        None => format!("({} bytes, no lines)", content.len()),
+    };
+    format!(
+        "no match found for old_string in {path}; the file may have \
+         changed since you read it. Nearest candidate:\n{}",
+        truncate_output(&excerpt, SNAPSHOT_MAX_BYTES),
+    )
+}
+
+/// 1-based line number of the line most similar to `old`, by
+/// normalized token overlap. Ties go to the earliest line; zero
+/// overlap anywhere anchors at the top. `None` only when the file
+/// has no lines at all.
+fn nearest_line(content: &str, old: &str) -> Option<usize> {
+    let normalized_old = normalize_line(old);
+    let needle: HashSet<&str> = normalized_old
+        .split(' ')
+        .filter(|t| !t.is_empty())
+        .collect();
+    content
+        .lines()
+        .map(|line| {
+            let normalized = normalize_line(line);
+            let tokens: HashSet<&str> = normalized.split(' ').collect();
+            needle.intersection(&tokens).count()
+        })
+        .enumerate()
+        .max_by_key(|&(i, overlap)| (overlap, Reverse(i)))
+        .map(|(i, overlap)| if overlap > 0 { i + 1 } else { 1 })
+}
+
+/// Numbered lines around `center` (inclusive), in `file_read`'s
+/// `line\tcontent` format. A header line names the window so the
+/// model can tell a partial excerpt from the whole file; it leads the
+/// excerpt so the byte cap cannot cut it off.
+fn excerpt_around(content: &str, center: usize) -> String {
+    use std::fmt::Write;
+
+    let total = content.lines().count();
+    let from = center.saturating_sub(CONTEXT_LINES).max(1);
+    let to = (center + CONTEXT_LINES).min(total);
+
+    let mut out = String::new();
+    if from > 1 || to < total {
+        let _ = writeln!(out, "[showing lines {from}-{to} of {total}]");
+    }
+    let _ = write!(out, "{}", numbered_lines(content, from, to));
+    out
+}
+
 /// 1-based line number of a byte position.
 fn line_of(content: &str, pos: usize) -> usize {
     content[..pos].bytes().filter(|&b| b == b'\n').count() + 1
@@ -237,20 +302,12 @@ fn line_of(content: &str, pos: usize) -> usize {
 /// Context lines on each side of an edited region in the success echo.
 const CONTEXT_LINES: usize = 3;
 
-/// Render the region at `[start, start + len)` with line numbers and
-/// context, in `file_read`'s `line\tcontent` format.
-fn echo_region(content: &str, start: usize, len: usize) -> String {
+/// Numbered lines `from..=to` (1-based, inclusive), in `file_read`'s
+/// `line\tcontent` format. `to` clamps to the last line.
+fn numbered_lines(content: &str, from: usize, to: usize) -> String {
     use std::fmt::Write;
 
-    let first = line_of(content, start);
-    let last = if len == 0 {
-        first
-    } else {
-        line_of(content, start + len - 1)
-    };
-    let from = first.saturating_sub(CONTEXT_LINES).max(1);
-    let to = last + CONTEXT_LINES;
-
+    let to = to.min(content.lines().count());
     content
         .lines()
         .enumerate()
@@ -260,6 +317,22 @@ fn echo_region(content: &str, start: usize, len: usize) -> String {
             let _ = writeln!(acc, "{}\t{line}", i + 1);
             acc
         })
+}
+
+/// Render the region at `[start, start + len)` with line numbers and
+/// context, in `file_read`'s `line\tcontent` format.
+fn echo_region(content: &str, start: usize, len: usize) -> String {
+    let first = line_of(content, start);
+    let last = if len == 0 {
+        first
+    } else {
+        line_of(content, start + len - 1)
+    };
+    numbered_lines(
+        content,
+        first.saturating_sub(CONTEXT_LINES).max(1),
+        last + CONTEXT_LINES,
+    )
 }
 
 /// Strip trailing whitespace only.
@@ -378,6 +451,73 @@ mod tests {
             Err(ToolError::Precondition(msg)) => {
                 assert!(msg.contains("may have changed since you read it"), "{msg}");
                 assert!(msg.contains("hello world"), "{msg}");
+            }
+            other => panic!("expected Precondition, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn no_match_excerpt_anchors_on_nearest_candidate() {
+        // Line 5 shares "fn" and "{" with the needle; every other line
+        // shares nothing. The excerpt must center on line 5, not dump
+        // the file.
+        let content = "mod a;\nmod b;\nmod c;\nmod d;\nfn stale_read_message() {\n}\n\
+                       mod e;\nmod f;\nmod g;\n";
+        let (_dir, tool) = setup(content);
+        let result = edit(&tool, "fn stale_read_message(&self) {", "x").await;
+        match result {
+            Err(ToolError::Precondition(msg)) => {
+                assert!(msg.contains("[showing lines 2-8 of 9]"), "{msg}");
+                assert!(msg.contains("5\tfn stale_read_message() {"), "{msg}");
+                assert!(!msg.contains("1\tmod a;"), "{msg}");
+                assert!(!msg.contains("9\tmod g;"), "{msg}");
+            }
+            other => panic!("expected Precondition, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn no_match_excerpt_is_bounded_on_large_files() {
+        // No token overlap anywhere: the excerpt anchors at the top and
+        // the long lines push it past the byte cap.
+        let content = format!("{}\n", "x".repeat(600)).repeat(100);
+        let (_dir, tool) = setup(&content);
+        let result = edit(&tool, "fn stale_read_message(&self) {", "x").await;
+        match result {
+            Err(ToolError::Precondition(msg)) => {
+                assert!(
+                    msg.len() <= SNAPSHOT_MAX_BYTES + 256,
+                    "msg is {} bytes",
+                    msg.len()
+                );
+                assert!(msg.contains("[showing lines 1-4 of 100]"), "{msg}");
+                assert!(msg.contains("[truncated"), "{msg}");
+            }
+            other => panic!("expected Precondition, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn no_match_with_zero_overlap_anchors_at_top() {
+        let (_dir, tool) = setup("alpha\nbeta\n");
+        let result = edit(&tool, "zzz qqq", "x").await;
+        match result {
+            Err(ToolError::Precondition(msg)) => {
+                assert!(msg.contains("1\talpha"), "{msg}");
+                assert!(msg.contains("2\tbeta"), "{msg}");
+                assert!(!msg.contains('['), "{msg}");
+            }
+            other => panic!("expected Precondition, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn no_match_on_empty_file_names_byte_count() {
+        let (_dir, tool) = setup("");
+        let result = edit(&tool, "anything", "x").await;
+        match result {
+            Err(ToolError::Precondition(msg)) => {
+                assert!(msg.contains("(0 bytes, no lines)"), "{msg}");
             }
             other => panic!("expected Precondition, got {other:?}"),
         }


### PR DESCRIPTION
## Problem

A `file_edit` no-match embedded the whole file into the `Precondition` error. That one string is three things at once: the model-facing tool result, the agent's ERROR log line, and the error-tee entry. The tee has no per-entry cap and the self-analysis duty truncates its whole errors section at `SECTION_MAX_BYTES`, so one mismatch on a large file evicted every other incident in the window — observed 2026-08-13 with `src/duty/mod.rs` quoted wholesale into the journal. Spec 24's doctrine ("entry size is a correctness concern") postdates the spec 03 text that deliberately delegated snapshot size to the engines; this retires that delegation.

## Changes

**Model-facing (`src/tools/file_edit.rs`)** — the stale-read error now carries a bounded excerpt around the *nearest candidate line*: the line with the highest normalized-token overlap with `old_string` (ties to the earliest; zero overlap anchors at the top), rendered in `file_read`'s `line\tcontent` format with three context lines each side, a `[showing lines X-Y of Z]` header when the window is partial, capped at 2 KiB via the existing `truncate_output` (reused, no third helper). An excerpt around the nearest match beats a full dump for re-synchronization anyway — the model gets line anchors near where it was editing instead of a wall of source to re-scan, and files large enough to matter were getting stubbed out of context by the engine regardless.

**Log/tee-facing (`src/error.rs`)** — `log_summary` caps `Precondition` renderings at 500 bytes via `truncate_output`. The exhaustive match is the fence: each variant must answer whether its payload is safe to log whole, and `Precondition`'s answer changed to no the moment `file_edit` started embedding content excerpts in it. All other producers (git rebase/fixup/push preconditions, notify rate limit, exec missing-cwd, ls-remote) lead with operation and failure mode and log whole under the cap; the variant doc now states that phrasing requirement so future producers keep it.

**Rendering unified** — the excerpt and the success echo share one `numbered_lines` renderer, which also fixes `echo_region`'s unclamped end line (it relied on iterator exhaustion instead of clamping).

**Spec 03** — stale-read paragraph rewritten; failure-mode table rows corrected (`ExecutionFailed` → `Precondition`; the generic row still named the retired variant, corrected to `CommandFailed`).

## Tests

- `no_match_excerpt_anchors_on_nearest_candidate` — excerpt centers on the best-overlap line, not the file start
- `no_match_excerpt_is_bounded_on_large_files` — 100×600-byte file: message ≤ cap, `[showing lines 1-4 of 100]` header survives, `[truncated N bytes]` note present
- `no_match_with_zero_overlap_anchors_at_top` — no header when the window covers the whole file
- `no_match_on_empty_file_names_byte_count` — `(0 bytes, no lines)`
- `precondition_log_summary_is_capped` / `short_precondition_logs_whole` — the log cap and its no-op case

`just check` passes (clippy `--deny warnings`, fmt, tests, nix, cargo deny).

Closes #49