### PR TITLE
Allow pnpm.io through the egress proxy

### DIFF
--- a/specs/18-egress-filter.md
+++ b/specs/18-egress-filter.md
@@ -40,8 +40,20 @@ is the only path out.
 | `githubusercontent.com` | GitHub raw content, git objects |
 | `flakehub.com` | FlakeHub Nix registry |
 | `api.perplexity.ai` | Web search tool |
+| `api.linear.app` | Linear API |
+| `bitcoinknowledge.dev` | bkb MCP server backend (spec 22) |
+| `npmjs.org` | npm/pnpm registry (devShell installs) |
+| `yarnpkg.com` | yarn registry (devShell installs) |
+| `pnpm.io` | pnpm docs — the dependency-maintenance duty reads override/config references |
+| `crates.io` | cargo registry (devShell installs) |
+| `pypi.org` | pip index (devShell installs) |
+| `pythonhosted.org` | pip package files (devShell installs) |
+| `rubygems.org` | gem registry (devShell installs) |
+| `doc.rust-lang.org` | rustdoc (devShell toolchain docs) |
 
-Each domain matches itself and all subdomains.
+Plus one anchored ERE in `egressAllowlistPatterns` (GitHub Actions
+log/artifact downloads, see the option's comment). Each domain matches
+itself and all subdomains.
 
 ### tinyproxy Configuration
 
@@ -106,7 +118,7 @@ The proxy must accept connections before the daemon starts.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `egressAllowlist` | list of str | (7 domains above) | Domains the kitaebot process may connect to |
+| `egressAllowlist` | list of str | (the default allowlist above) | Domains the kitaebot process may connect to |
 
 ### Side Effects
 

--- a/vm/configuration.nix
+++ b/vm/configuration.nix
@@ -211,6 +211,7 @@ in
         # Package registries: devShells fetch project dependencies here.
         "npmjs.org"
         "yarnpkg.com"
+        "pnpm.io"
         "crates.io"
         "pypi.org"
         "pythonhosted.org"


### PR DESCRIPTION
## Problem

During the lightning-node dependency-security lane (2026-08-23), the reviewer sub-agent tried to fetch pnpm overrides documentation and tinyproxy refused the CONNECT:

```
19:18:29 tinyproxy NOTICE: Proxying refused on filtered domain "pnpm.io" (x2)
```

It fell back to a guessed `raw.githubusercontent.com` path and 404'd, burning three iterations of a turn that then hit the iteration cap. A duty whose whole job is pnpm dependency maintenance has a concrete caller for pnpm.io docs — this meets the "every permission needs a concrete caller" bar. (Registry traffic itself already goes to `registry.npmjs.org`, which is allowlisted; pnpm.io is the docs/config-reference site.)

## Change

**`vm/configuration.nix`** — one entry: `"pnpm.io"` in `egressAllowlist`'s registry group. The anchored ERE generator emits `^(.*\.)?pnpm\.io$`, matching pnpm.io and its subdomains only.

**`specs/18-egress-filter.md`** — the Default Allowlist table had been stale since a82be0f added the package registries (and f548bb0 the MCP backend) without updating it: it still listed the original 7 domains while the default carried 16. The table now lists all 17 with purposes, notes the one anchored ERE in `egressAllowlistPatterns`, and the Module Options row no longer claims "(7 domains above)". Specs are contracts; this one is the contract for the list being changed.

## Verification

- `nixfmt --check` clean; `just check` (nix flake check, clippy, fmt, tests, cargo deny) passes.
- The generated filter was verified by evaluating the egress test's own node config and reading the filter file back — it contains `^(.*\.)?pnpm\.io$` alongside the other 17 patterns.
- The full egress NixOS VM test could not run in this environment: the VM's disk-pressure GC (disk at 91%, `min-free = 3 GiB`) deletes store paths mid-build. Environment failure, unrelated to the diff; the test is unchanged and none of its subtests reference pnpm.io. It runs in CI with KVM.

Closes #69