### PR TITLE
Accept string-encoded numerics in LCM tool args

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -39,8 +39,9 @@ JSON value (e.g. `"review": "{\"repo\":\"...\"}"` instead of
 `"limit": 30`). Fields prone to this use the `string_or_value`
 deserializer, which parses the inner JSON string before deserializing into
 the target type. Applied to `task`'s `review` parameter,
-`github_api`'s `body` parameter, and `file_read`'s `offset`/`limit`
-parameters.
+`github_api`'s `body` parameter, `file_read`'s `offset`/`limit`
+parameters, `lcm_grep`'s `limit` parameter, and `lcm_expand`'s
+`depth`/`include_messages`/`token_cap` parameters.
 
 ### Per-Turn Context
 

--- a/src/context/lcm/tools.rs
+++ b/src/context/lcm/tools.rs
@@ -26,7 +26,7 @@ use tracing::debug;
 
 use super::explore::extract_file_ids;
 use crate::error::ToolError;
-use crate::tools::{Tool, ToolCtx};
+use crate::tools::{Tool, ToolCtx, string_or_value};
 use crate::types::estimate_tokens;
 
 /// Default result limit for `lcm_grep`. Generous but capped so a
@@ -104,7 +104,7 @@ struct GrepArgs {
     #[serde(default)]
     scope: Option<String>,
     /// Max results returned. Defaults to 50; capped at 200.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "string_or_value")]
     limit: Option<u32>,
 }
 
@@ -558,14 +558,14 @@ struct ExpandArgs {
     summary_id: String,
     /// Levels to expand (default 1). Each level fetches one DAG step
     /// further from `summary_id`.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "string_or_value")]
     depth: Option<u32>,
     /// Include raw source messages for leaf summaries (default false).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "string_or_value")]
     include_messages: Option<bool>,
     /// Token cap on response. Default 5000; capped at 20000. Stops
     /// expansion early once the cap is reached.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "string_or_value")]
     token_cap: Option<u32>,
 }
 
@@ -985,6 +985,30 @@ mod tests {
             .await
             .unwrap();
         assert!(out.starts_with("No matches"));
+    }
+
+    #[test]
+    fn grep_args_accept_string_encoded_limit() {
+        let args: GrepArgs = serde_json::from_value(serde_json::json!({
+            "pattern": "x",
+            "limit": "5",
+        }))
+        .unwrap();
+        assert_eq!(args.limit, Some(5));
+    }
+
+    #[test]
+    fn expand_args_accept_string_encoded_values() {
+        let args: ExpandArgs = serde_json::from_value(serde_json::json!({
+            "summary_id": "sum_x",
+            "depth": "2",
+            "include_messages": "true",
+            "token_cap": "100",
+        }))
+        .unwrap();
+        assert_eq!(args.depth, Some(2));
+        assert_eq!(args.include_messages, Some(true));
+        assert_eq!(args.token_cap, Some(100));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`lcm_grep` fails with `invalid type: string "5", expected u32` when the LLM passes `limit` as a string-encoded integer (`"limit": "5"` instead of `"limit": 5`). PR #25 added the `string_or_value` deserializer to `file_read`'s `offset`/`limit` for exactly this double-encoding class, but the LCM tools were missed.

## Fix

Apply the existing `string_or_value` deserializer (src/tools/mod.rs, no new copy) to:

- `lcm_grep`: `limit`
- `lcm_expand`: `depth`, `include_messages`, `token_cap`

`lcm_describe`'s only field is a required string, where `string_or_value` does not apply. Spec 03-tools.md's enumeration of covered fields is updated to match.

## How to verify

- `just check` passes.
- New tests `grep_args_accept_string_encoded_limit` and `expand_args_accept_string_encoded_values` in src/context/lcm/tools.rs deserialize `{"pattern":"x","limit":"5"}` and string-encoded `depth`/`include_messages`/`token_cap` successfully.

Fixes #64