### PR TITLE
Exclude the e2e suite from just test

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ just audit               # Supply-chain audit: RustSec advisories, sources, bans
 just bench-build [rev]   # Benchmark cold/link-heavy builds; optional rev to compare against
 just build               # Compile
 just warm                # Warm the shared cargo target dir, sweep stale artifacts, gcroot the dep closure
-just test                # Run tests (mock-network feature)
+just test                # Run tests in the commit gate's scope plus confine (e2e excluded)
 just test-e2e            # E2e suite: real daemon against a loopback fixture server
-just test-one NAME       # Run tests matching a name
+just test-one NAME       # Run tests matching a name across every target, e2e included
 just test-nixos          # Run all NixOS VM integration tests
 just test-nixos-one NAME # Run a single NixOS VM test (e.g. egress)
 just lint                # Clippy with --deny warnings

--- a/justfile
+++ b/justfile
@@ -46,16 +46,19 @@ warm:
     cargo sweep --maxsize 12GB
     mkdir -p .gcroots && nix build .#deps --out-link .gcroots/deps
 
-# Run tests
+# Run tests in the commit gate's scope, plus confine (self-skips
+# without Landlock, so this is its only live runner); e2e is excluded
+# to match the gate, run it with `just test-e2e`
 test:
-    cargo test --features mock-network
+    cargo test --features mock-network --bins --test kchat --test confine
 
 # Run the e2e suite (real daemon against a loopback fixture server;
 # excluded from `nix flake check` to keep the commit gate fast)
 test-e2e:
     cargo test --features mock-network --test e2e
 
-# Run tests matching a name (e.g. just test-one report_counts)
+# Run tests matching a name across every target, e2e included
+# (e.g. just test-one report_counts)
 test-one name:
     cargo test --features mock-network {{name}}
 


### PR DESCRIPTION
## Problem

`just rust-check` is documented as the fast inner loop, but it calls `just test` = `cargo test --features mock-network`, which builds and runs every test target including `tests/e2e.rs` (spawns a real daemon, socket roundtrips). The commit gate (`nix flake check`) deliberately excludes e2e via `cargoTestExtraArgs = "--features mock-network --bins --test kchat"`, so the "fast" loop was slower than the gate and has timed out at 600s.

The `test` recipe predates every integration suite (it was a bare `cargo test` before e2e existed); when the e2e fixture server landed, the flake was scoped and `test-e2e` added, but `just test` was left unscoped and silently absorbed the suite.

## Fix

- `just test` now runs `cargo test --features mock-network --bins --test kchat --test confine`: the gate's scope plus `tests/confine.rs`. Confine is kept because it self-skips in the nix sandbox (no Landlock), making `just test` its only automatic live runner outside the VM; dropping it to mirror the gate exactly would silently retire that coverage. It costs a few process spawns against an already-built binary.
- `just test-e2e` is unchanged and remains the explicit e2e entry point.
- `just test-one` stays unscoped on purpose (only way to run a single e2e test by name); its comment now says so.
- README recipe descriptions updated to match. CI is unaffected: it runs `nix flake check`, never `just test`.

## How to verify

- `just test 2>&1 | grep Running` lists the two bins, `tests/confine.rs`, and `tests/kchat.rs`; `tests/e2e.rs` is absent.
- `just test-e2e` still runs the e2e suite.
- `just check` passes (unchanged; the flake scope was not touched).

Fixes #58