### PR TITLE
Redact bot token from Telegram network errors

### DIFF
--- a/src/clients/telegram.rs
+++ b/src/clients/telegram.rs
@@ -55,12 +55,9 @@ impl TelegramClient {
                         .body(body)
                         .send()
                         .await
-                        .map_err(|e| TelegramError::Network(e.to_string()))?;
+                        .map_err(|e| network_error(&method, e))?;
                     let status = resp.status().as_u16();
-                    let bytes = resp
-                        .bytes()
-                        .await
-                        .map_err(|e| TelegramError::Network(e.to_string()))?;
+                    let bytes = resp.bytes().await.map_err(|e| network_error(&method, e))?;
                     Ok(RawResponse {
                         status,
                         body: bytes.to_vec(),
@@ -110,6 +107,20 @@ impl TelegramClient {
         let raw = (self.post)("sendMessage".into(), raw_body).await?;
         interpret_response(&raw)
     }
+}
+
+/// Transport error → [`TelegramError::Network`], with the URL stripped:
+/// its path embeds the bot token. The method name and joined source
+/// chain replace what the URL carried.
+fn network_error(method: &str, e: reqwest::Error) -> TelegramError {
+    let e = e.without_url();
+    let chain = std::iter::successors(Some(&e as &(dyn std::error::Error + 'static)), |e| {
+        e.source()
+    })
+    .map(ToString::to_string)
+    .collect::<Vec<_>>()
+    .join(": ");
+    TelegramError::Network(format!("{method}: {chain}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -337,6 +348,33 @@ mod tests {
         let json = api_error_json(429, "Too Many Requests");
         let err = interpret_response::<Vec<Update>>(&raw(&json)).unwrap_err();
         assert_eq!(err.retry_after(), None);
+    }
+
+    // -- network_error tests --
+
+    #[tokio::test]
+    async fn network_error_redacts_token_url() {
+        let token = "123456:AAF-secret";
+        // Bind-and-drop yields a loopback port that refuses connections.
+        let addr = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap();
+        let url = format!("http://{addr}/bot{token}/getUpdates");
+        let e = crate::clients::http_client(reqwest::Client::builder())
+            .post(&url)
+            .send()
+            .await
+            .expect_err("connection to dropped port must fail");
+        assert!(
+            e.to_string().contains(token),
+            "precondition: reqwest Display carries the URL"
+        );
+
+        let msg = network_error("getUpdates", e).to_string();
+        assert!(!msg.contains(token), "token leaked: {msg}");
+        assert!(msg.contains("getUpdates"));
+        assert!(msg.contains("Connection refused"), "lost cause: {msg}");
     }
 
     // -- Client integration tests via from_fn --


### PR DESCRIPTION
## Problem

reqwest's error Display includes the request URL, and the Telegram Bot API URL embeds the bot token in its path. The client built `TelegramError::Network` from `e.to_string()`, so a poll failure logged the token to the VM journal in plaintext:

    ERROR kitaebot::channel::telegram: Telegram poll error: error sending request for url (https://api.telegram.org/bot<TOKEN>/getUpdates)

Journals get dumped for debugging (`just vm-logs-dump`), leaking the token into scrollback and pastes.

## Fix

Redact at error construction, not at the log site. The new `network_error` helper in `src/clients/telegram.rs` strips the URL with `reqwest::Error::without_url()` and stringifies from there, so every downstream log of a `TelegramError::Network` (poll loop, send retries, daemon) is safe by construction. No string scrubbing.

reqwest 0.13's Display carries the URL but not the source chain, so the old string also hid the actual cause of a failure. The helper joins the full source chain and the API method name in place of the URL, keeping the diagnostic detail (DNS, connect, timeout causes) while dropping the secret.

Audit: only the Telegram client puts a secret in a URL. GitHub, Linear, and chat-completion clients authenticate via headers; `web_fetch` URLs are not secrets. Their error paths are unchanged.

## How to verify

- `just check` passes; new test `clients::telegram::tests::network_error_redacts_token_url` drives a real reqwest connection-refused error for a token-bearing loopback URL through the helper and asserts the token is absent, the method name is present, and the cause survives.
- Manually: point `telegram.api_base` at an unreachable host and watch `just vm-logs`; the poll error now reads `Network error: getUpdates: error sending request: ...` with no URL.

After merge: rotate the current bot token, since it is already in existing journals.

Fixes #67
