### PR TITLE
Classify FTS5 pattern failures in lcm_grep

### DIFF
--- a/specs/14-context-engine.md
+++ b/specs/14-context-engine.md
@@ -792,9 +792,17 @@ The LCM engine contributes three tools via `tools()`:
 
 `fts` mode uses SQLite FTS5 — token-based matching with boolean operators
 (`AND`, `OR`, `NOT`, phrase queries). This is the fast path for keyword
-searches. Patterns that fail FTS5 parsing (punctuation-heavy literals like
-`isl-0.20`, which models pass routinely) are retried once as a quoted
-phrase instead of surfacing the syntax error.
+searches. Plain patterns that fail FTS5 parsing (punctuation-heavy literals
+like `isl-0.20`, which models pass routinely) are retried once as a quoted
+phrase instead of surfacing the syntax error. This covers "no such column"
+failures too: in FTS5 query syntax `-term` and `term:` are column filters,
+so a hyphenated or coloned literal parses as a reference to a nonexistent
+column. Patterns using explicit operator syntax (quotes, uppercase
+`AND`/`OR`/`NOT`/`NEAR(`) are never phrase-quoted, since that would
+silently drop the operators; when such a pattern fails to parse (or the
+phrase retry itself fails), the tool returns `ToolError::FtsQuery`, which
+names the pattern verbatim, keeps the sqlite error as source, and tells
+the model to quote punctuated terms or switch to regex mode.
 
 `regex` mode uses a `REGEXP` user function registered on the SQLite connection.
 It scans the `content` column directly (no index), so it is slower than FTS but
@@ -1079,7 +1087,7 @@ For LCM, an unknown name simply creates a new conversation row.
 | Session not found on switch | — | Created automatically (idempotent) |
 | Active session file missing | — | Fall back to `general` |
 | Active session file corrupt | — | Fall back to `general` |
-| FTS query fails | `EngineError::Storage` | Error text returned to LLM via tool error |
+| FTS pattern rejected | `ToolError::FtsQuery` | Phrase retry for plain literals; operator patterns get the error, naming the pattern with guidance |
 | Regex query timeout / invalid pattern | `ToolError::ExecutionFailed` | Error text returned to LLM |
 | Token cap exceeded during expand | — | Partial result with `truncated: true` |
 | Large file exploration summary fails | — | Fall back to size + MIME metadata only |

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -900,6 +900,7 @@ fn error_class(err: &ToolError) -> String {
         ToolError::Blocked { .. } => "blocked".into(),
         ToolError::Cancelled => "cancelled".into(),
         ToolError::CommandFailed { exit_code, .. } => format!("command_failed:{exit_code}"),
+        ToolError::FtsQuery { .. } => "fts_query".into(),
         ToolError::Github(e) => match e {
             crate::error::GithubError::Api { status, .. } => format!("github:api:{status}"),
             crate::error::GithubError::Deserialize(_) => "github:deserialize".into(),

--- a/src/context/lcm/tools.rs
+++ b/src/context/lcm/tools.rs
@@ -93,9 +93,10 @@ fn snippet(s: &str) -> String {
 #[derive(Deserialize, JsonSchema)]
 struct GrepArgs {
     /// Search pattern. FTS5 query syntax in `fts` mode (token search,
-    /// boolean operators, phrase queries); patterns that fail to parse
-    /// as FTS5 syntax (e.g. dotted literals like `isl-0.20`) are
-    /// retried as a quoted phrase. Rust regex syntax in `regex` mode.
+    /// boolean operators, phrase queries); plain literals that fail to
+    /// parse (e.g. `isl-0.20`) are retried as a quoted phrase. Inside
+    /// operator queries, quote punctuated terms: `"security-lane" OR
+    /// alert`. Rust regex syntax in `regex` mode.
     pattern: String,
     /// `fts` (default) or `regex`.
     #[serde(default)]
@@ -187,11 +188,35 @@ fn fts_phrase(pattern: &str) -> String {
     format!("\"{}\"", pattern.replace('"', "\"\""))
 }
 
-fn is_fts_syntax_error(e: &ToolError) -> bool {
-    // SQLite reports it as a generic SQLITE_ERROR, so the fts5 detail
-    // only exists in the message; the variant match scopes the sniff
-    // to our own store's errors.
-    matches!(e, ToolError::Sqlite { source, .. } if source.to_string().contains("fts5: syntax error"))
+fn is_fts_parse_error(e: &ToolError) -> bool {
+    // SQLite reports both shapes as a generic SQLITE_ERROR, so the
+    // fts5 detail only exists in the message; the variant match scopes
+    // the sniff to our own store's errors. "no such column" is the
+    // query parser resolving a `-term`/`term:` column filter, the only
+    // caller-controlled column reference in fts mode.
+    matches!(e, ToolError::Sqlite { source, .. } if {
+        let msg = source.to_string();
+        msg.contains("fts5: syntax error") || msg.starts_with("no such column:")
+    })
+}
+
+/// True when the pattern uses explicit FTS5 query syntax, so
+/// phrase-quoting it whole would silently drop the operators.
+fn uses_fts_operators(pattern: &str) -> bool {
+    pattern.contains('"')
+        || pattern
+            .split_whitespace()
+            .any(|t| matches!(t, "AND" | "NOT" | "OR") || t.starts_with("NEAR("))
+}
+
+fn fts_query_error(pattern: &str, e: ToolError) -> ToolError {
+    match e {
+        ToolError::Sqlite { source, .. } => ToolError::FtsQuery {
+            pattern: pattern.to_owned(),
+            source,
+        },
+        other => other,
+    }
 }
 
 fn run_grep(
@@ -216,10 +241,21 @@ fn run_grep(
     };
 
     // LLMs routinely pass literal strings full of FTS5-hostile
-    // punctuation. When the raw pattern is not valid query syntax,
-    // retry it as a quoted phrase instead of surfacing the parse error.
+    // punctuation. When a plain pattern is not valid query syntax,
+    // retry it as a quoted phrase; operator-bearing patterns (and a
+    // failed retry) get the structured error instead.
     let hits = match run(pattern) {
-        Err(e) if mode == "fts" && is_fts_syntax_error(&e) => run(&fts_phrase(pattern))?,
+        Err(first) if mode == "fts" && is_fts_parse_error(&first) => {
+            if uses_fts_operators(pattern) {
+                return Err(fts_query_error(pattern, first));
+            }
+            match run(&fts_phrase(pattern)) {
+                Err(retry) if is_fts_parse_error(&retry) => {
+                    return Err(fts_query_error(pattern, first));
+                }
+                other => other?,
+            }
+        }
         other => other?,
     };
 
@@ -944,10 +980,63 @@ mod tests {
         assert!(out.contains("hello.world"), "missing match in: {out}");
     }
 
+    #[tokio::test]
+    async fn lcm_grep_fts_hyphenated_literal_falls_back_to_phrase() {
+        let (_dir, db) = fresh_db();
+        let writer = schema::open(&db).unwrap();
+        insert_message(&writer, 1, "user", "the security-lane alert fired");
+
+        let tool = LcmGrep::new(schema::open_readonly(&db).unwrap(), shared_active(1));
+        // Raw `security-lane` fails as "no such column: lane"; the
+        // phrase retry must find the row anyway.
+        let out = tool
+            .execute(
+                serde_json::json!({"pattern": "security-lane"}),
+                ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+        assert!(out.contains("security-lane alert"), "missing match: {out}");
+    }
+
+    #[tokio::test]
+    async fn lcm_grep_fts_operator_pattern_with_bad_term_names_the_pattern() {
+        let (_dir, db) = fresh_db();
+        let pattern = "security lane OR security-lane OR \"fix every alert\"";
+        let tool = LcmGrep::new(schema::open_readonly(&db).unwrap(), shared_active(1));
+        let err = tool
+            .execute(serde_json::json!({"pattern": pattern}), ToolCtx::default())
+            .await
+            .unwrap_err();
+        let ToolError::FtsQuery { .. } = &err else {
+            panic!("expected FtsQuery, got: {err}");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&format!("{pattern:?}")),
+            "pattern not named: {msg}"
+        );
+        assert!(msg.contains("no such column: lane"), "cause lost: {msg}");
+        assert!(msg.contains("mode=\"regex\""), "no guidance: {msg}");
+        let source = std::error::Error::source(&err).expect("sqlite cause dropped");
+        assert!(source.to_string().contains("no such column: lane"));
+    }
+
     #[test]
     fn fts_phrase_quotes_and_escapes() {
         assert_eq!(fts_phrase("isl-0.20"), "\"isl-0.20\"");
         assert_eq!(fts_phrase("a \"b\" c"), "\"a \"\"b\"\" c\"");
+    }
+
+    #[test]
+    fn uses_fts_operators_detects_intent() {
+        assert!(uses_fts_operators("a OR b"));
+        assert!(uses_fts_operators("NOT b"));
+        assert!(uses_fts_operators("NEAR(a b)"));
+        assert!(uses_fts_operators("\"a phrase\""));
+        assert!(!uses_fts_operators("isl-0.20"));
+        assert!(!uses_fts_operators("or and near"));
+        assert!(!uses_fts_operators("schema::open"));
     }
 
     #[tokio::test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -205,6 +205,23 @@ pub enum ToolError {
         output: String,
     },
 
+    /// FTS5 rejected an `lcm_grep` search pattern as query syntax and
+    /// the phrase fallback could not apply. Carries the pattern
+    /// verbatim and guidance, since the sqlite message alone ("no such
+    /// column: lane") names neither the operation nor the input.
+    #[error(
+        "FTS5 failed to parse search pattern {pattern:?}: {source}. \
+         Hyphens and colons are query syntax in fts mode; quote each \
+         literal term (\"security-lane\") or use mode=\"regex\"."
+    )]
+    FtsQuery {
+        /// The pattern exactly as supplied.
+        pattern: String,
+        /// The underlying FTS5 parse failure.
+        #[source]
+        source: rusqlite::Error,
+    },
+
     /// A GitHub API call made by a tool failed.
     ///
     /// Transparent: [`GithubError`] already distinguishes a non-2xx
@@ -384,6 +401,7 @@ impl ToolError {
             // what the service returns, so they log whole.
             Self::Blocked { .. }
             | Self::Cancelled
+            | Self::FtsQuery { .. }
             | Self::Github(_)
             | Self::Http { .. }
             | Self::HttpStatus { .. }


### PR DESCRIPTION
## Problem

`lcm_grep` in fts mode passes the model's pattern straight into an FTS5 MATCH. The pattern `security lane OR security-lane OR "fix every alert"` failed with the raw sqlite message `lcm: no such column: lane`, which names neither the operation (FTS5 query parse) nor the failing input.

Root cause: in FTS5 query syntax, `-term` and `term:` are column filters, and the parser resolves the column name as soon as the filter is reduced. `security-lane` therefore parses as an exclusion filter on a column named `lane`, so the failure surfaces as "no such column: lane" instead of "fts5: syntax error", escaping the existing quoted-phrase retry (which sniffed only for the latter).

## Fix

- Widen the retry classifier (`is_fts_parse_error`) to also accept "no such column", which in fts mode can only come from the caller-controlled MATCH expression. Plain hyphenated/coloned literals (`security-lane`, `schema::open`) now get rescued by the phrase retry the same way `isl-0.20` already was. Locked-database and corruption errors match neither shape and propagate untouched.
- Patterns using explicit operator syntax (quotes, uppercase `AND`/`OR`/`NOT`/`NEAR(`) are excluded from the retry: phrase-quoting an operator query silently drops the operators and reports a false "no matches". Those patterns, and any pattern whose phrase retry also fails, now return the new `ToolError::FtsQuery` variant, which names the operation, carries the pattern verbatim, keeps the sqlite error as `#[source]`, and tells the model to quote punctuated terms or use `mode="regex"`.
- Spec 14's `lcm_grep` section and error table updated to match.

## How to verify

- `just check` passes (fmt, clippy, tests, nix, deny).
- `just test-one lcm_grep` covers: the exact issue pattern returns `FtsQuery` naming the pattern with the sqlite cause and guidance; `security-lane` alone is rescued by the phrase retry and finds its row; existing `isl-0.20`, embedded-quote, regex, and isolation tests unchanged.
- Manual: `just ask` the daemon to run `lcm_grep` with the issue's pattern; the tool error now reads `FTS5 failed to parse search pattern "security lane OR security-lane OR \"fix every alert\"": no such column: lane. Hyphens and colons are query syntax in fts mode; quote each literal term ("security-lane") or use mode="regex".`

Fixes #71
