### PR TITLE
Run the e2e suite in the commit gate

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,9 +92,9 @@
             commonArgs
             // {
               inherit cargoArtifacts;
-              # e2e is excluded to keep `nix flake check` fast; run it
-              # with `just test-e2e`.
-              cargoTestExtraArgs = "--features mock-network --bins --test kchat";
+              # e2e included: the suite is ~4s warm and sandbox-safe
+              # (loopback fixture server, /tmp-pinned git fixtures).
+              cargoTestExtraArgs = "--features mock-network --bins --test kchat --test e2e";
               # review_checkout tests spawn real git against a fixture repo.
               nativeCheckInputs = [ pkgs.git ];
             }

--- a/justfile
+++ b/justfile
@@ -50,8 +50,8 @@ warm:
 test:
     cargo test --features mock-network
 
-# Run the e2e suite (real daemon against a loopback fixture server;
-# excluded from `nix flake check` to keep the commit gate fast)
+# Run the e2e suite alone (real daemon against a loopback fixture
+# server; also part of `nix flake check`)
 test-e2e:
     cargo test --features mock-network --test e2e
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -77,6 +77,8 @@ impl Workspace {
         mk(&path.join("memory"))?;
         mk(&path.join("memory/topics"))?;
         mk(&path.join(PROJECTS_DIR))?;
+        // The git tier's Landlock rule can only grant an existing path.
+        mk(&path.join(REVIEWS_DIR))?;
         mk(&path.join(STATE_DIR))?;
         seed_review_checklist(&path)?;
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -2,8 +2,8 @@
 //!
 //! Requires the `mock-network` feature so client construction accepts
 //! only loopback hosts; the harness points the daemon at a local
-//! fixture server. Excluded from `nix flake check`; run with
-//! `just test-e2e`.
+//! fixture server. Runs in `nix flake check`; `just test-e2e` runs
+//! it alone.
 
 mod harness;
 
@@ -223,7 +223,7 @@ fn github_feedback_pass_dispatches_trusted_reviews_only() {
     // The future-stamped review can dispatch on more than one tick
     // before the cursor passes it; the rule must survive that.
     fixture.on_completion_always("by @alice: APPROVED", text("noted"));
-    let fixtures_root = tempfile::TempDir::new().unwrap();
+    let fixtures_root = harness::fixtures_root();
     let _daemon = TestDaemon::spawn_with(&fixture, &github_config(&fixture, fixtures_root.path()));
 
     // Quote-free matcher: the message is JSON-escaped inside the
@@ -241,7 +241,7 @@ fn github_feedback_pass_dispatches_trusted_reviews_only() {
 #[test]
 fn github_review_request_then_tracked_rereview() {
     let fixture = FixtureServer::start();
-    let fixtures_root = tempfile::TempDir::new().unwrap();
+    let fixtures_root = harness::fixtures_root();
     let sha1 = harness::git_fixture_pr_repo(fixtures_root.path(), "owner/repo", 7);
 
     let mut pr = github_pr("owner/repo", 7, "alice", "Fix bug");
@@ -292,7 +292,7 @@ fn github_contributed_pass_dispatches_trusted_comments_only() {
     // The future-stamped comments can dispatch on more than one tick
     // before the cursor passes them; the rule must survive that.
     fixture.on_completion_always("zero-diff", text("replied on the PR"));
-    let fixtures_root = tempfile::TempDir::new().unwrap();
+    let fixtures_root = harness::fixtures_root();
     let daemon = TestDaemon::spawn_with(&fixture, &github_config(&fixture, fixtures_root.path()));
 
     // The turn message names the third-party author and the bot's
@@ -367,7 +367,7 @@ fn duty_cadence_survives_restart() {
 #[test]
 fn duty_new_commits_gate_fires_only_on_new_commits() {
     let fixture = FixtureServer::start();
-    let fixtures_root = tempfile::TempDir::new().unwrap();
+    let fixtures_root = harness::fixtures_root();
     harness::git_fixture_pr_repo(fixtures_root.path(), "owner/repo", 1);
 
     fixture.on_completion_always("scan the new commits", text("scanned"));

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -179,3 +179,12 @@ impl Drop for TestDaemon {
         let _ = self.child.wait();
     }
 }
+
+/// Tempdir for fixture repos, pinned under /tmp: the daemon's git
+/// tier grants /tmp but not $TMPDIR (/build in the nix sandbox).
+pub fn fixtures_root() -> TempDir {
+    tempfile::Builder::new()
+        .prefix("kitaebot-e2e")
+        .tempdir_in("/tmp")
+        .unwrap()
+}


### PR DESCRIPTION
## Problem

Issue #58 flagged that `just test` and `nix flake check` disagreed about the test suite: the recipe ran e2e, the gate excluded it. The exclusion rationale was speed, but measurement says the suite is 15 tests in ~4s warm, host and sandbox alike. So this aligns in the opposite direction from the original proposal: the gate now runs e2e too.

## What making it pass in the sandbox surfaced

Two real defects, not sandbox quirks:

1. **Git fixture repos lived in $TMPDIR.** The daemon reads them through its confined git child, whose Landlock tier grants `/tmp` but not `/build` (the sandbox's TMPDIR). It only ever worked because host TMPDIR is /tmp. The harness now pins fixture repos under /tmp.
2. **Workspace init never created `reviews/`.** The git tier grants that path `Presence::Optional`, Landlock cannot grant a missing path, so the rule silently dropped and `git worktree` died with EACCES on checkout prep. This is live on prod: the VM has no `/var/lib/kitaebot/reviews` today, and its first review checkout that survives fetch would fail identically. `init_at` now creates it.

## Verify

`nix build .#checks.x86_64-linux.test` runs all 15 e2e tests in the sandbox (~4s). `just check` passes. `just test-e2e` still runs the suite alone.

Supersedes #78, which aligned the other way before the timing was measured.

Fixes #58