### PR TITLE
Grant exec children read access to /lib64

### DIFF
--- a/specs/15-sandbox.md
+++ b/specs/15-sandbox.md
@@ -70,6 +70,7 @@ The `exec` tier (`Policy::child_exec`):
 | `/nix/store` | read + execute | Binaries |
 | `/tmp` | working access | No device or socket creation |
 | `/etc`, `/run`, `/proc` | read | resolv.conf, CA certs, procfs |
+| `/lib64` | read | Build tooling scandirs it to detect libc (prisma postinstall); no execute, so the compat loader cannot run foreign binaries |
 | `/dev` | read + write | `/dev/null`, `/dev/urandom` |
 | Everything else | denied | Including the signing keyring at `/var/lib/kitaebot-gnupg`, which lives outside the workspace and is granted only in the daemon policy ([spec 13](13-credentials.md)) |
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -290,6 +290,12 @@ impl Policy {
                 rationale: "System config — read-only",
             },
             Rule {
+                path: PathBuf::from("/lib64"),
+                access: read_files,
+                presence: Presence::Optional,
+                rationale: "Loader dir — build tooling scandirs it to detect libc (prisma)",
+            },
+            Rule {
                 path: PathBuf::from("/run"),
                 access: read_files,
                 presence: Presence::Optional,
@@ -871,8 +877,21 @@ mod tests {
     fn child_expected_rule_count() {
         let policy = child_policy();
         // workspace root, projects, review checklist, 5 build caches,
-        // /nix/store, /tmp, /etc, /run, /dev, /proc
-        assert_eq!(policy.rules().len(), 14);
+        // /nix/store, /tmp, /etc, /lib64, /run, /dev, /proc
+        assert_eq!(policy.rules().len(), 15);
+    }
+
+    #[test]
+    fn child_lib64_is_read_only_no_execute() {
+        let policy = child_policy();
+        let rule = policy
+            .rules()
+            .iter()
+            .find(|r| r.path == Path::new("/lib64"))
+            .expect("/lib64 rule must exist");
+        assert_eq!(rule.access, AccessFs::ReadFile | AccessFs::ReadDir);
+        assert!(!rule.access.contains(AccessFs::Execute));
+        assert!(!rule.access.contains(AccessFs::WriteFile));
     }
 
     #[test]

--- a/src/tools/bwrap.rs
+++ b/src/tools/bwrap.rs
@@ -35,14 +35,18 @@ pub fn wrap_argv(workspace: &Path, cwd: &Path) -> Vec<String> {
     let mut push = |s: &str| argv.push(s.to_string());
 
     // Read-only system view: all binaries live in the nix store; /etc
-    // carries resolv.conf, CA certs, and nsswitch. `--ro-bind-try`
-    // tolerates a missing /etc in minimal test roots.
+    // carries resolv.conf, CA certs, and nsswitch; /lib64 is scandir'd
+    // by build tooling detecting libc (prisma). `--ro-bind-try`
+    // tolerates the path missing on minimal roots.
     push("--ro-bind");
     push("/nix/store");
     push("/nix/store");
     push("--ro-bind-try");
     push("/etc");
     push("/etc");
+    push("--ro-bind-try");
+    push("/lib64");
+    push("/lib64");
 
     // Fresh pseudo-filesystems and a private /tmp. The private /tmp
     // also denies a same-uid read of the git askpass file, which the
@@ -126,6 +130,11 @@ mod tests {
     #[test]
     fn store_is_read_only() {
         assert!(has_triple(&argv(), "--ro-bind", "/nix/store", "/nix/store"));
+    }
+
+    #[test]
+    fn lib64_is_bound_read_only() {
+        assert!(has_triple(&argv(), "--ro-bind-try", "/lib64", "/lib64"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The lightning-node dependency lane dies in pnpm postinstall: prisma generate scandirs `/lib64` to detect the host libc, the exec tier has no rule for it, and Landlock denies with EACCES. Five identical retries in 29s on 2026-08-23, then the turn hit its iteration cap. Recurs on every dependency-lane run against that repo.

## Fix

Minimum grant with a named caller:

- Landlock exec tier: `/lib64` gets `ReadFile | ReadDir`, `Presence::Optional`. **No Execute** — the compat loader in /lib64 cannot be used to run foreign prebuilt binaries; libc detection only lists and reads. The git tier inherits it.
- bwrap mode: matching `--ro-bind-try /lib64 /lib64` (tolerated missing on minimal roots).
- Spec 15 exec-tier table gets the row.

## Verify

Unit tests cover the rule shape (read-only, optional) and the bwrap bind. Live proof needs a VM rebuild plus a dependency-lane run against lightning-node: `just pnpm-install` should get past the prisma postinstall. Note the lane also needs #76 (pnpm.io egress) to complete end to end — this PR and that one are the two halves of the same broken duty.

Fixes #72