### PR TITLE
Bound each distillation pass to a token slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ kitaebot = {
     memory = {
       index_cap_bytes = 8192;                    # Byte cap on the injected MEMORY.md index
       distill_threshold_tokens = 40000;          # Undistilled tokens across all sessions before the distill duty runs
+      distill_slice_tokens = 10000;              # Per-pass token budget; unset = threshold. Backlogs drain slice by slice
     };
     provider = {
       api = "openrouter";                        # openrouter | openai | groq | together | mistral

--- a/deploy/configuration.nix
+++ b/deploy/configuration.nix
@@ -70,10 +70,10 @@ in
 
       context.engine = "lcm";
 
-      # WORKAROUND (kitaebot#47): 30 was too small for distillation to
-      # clear a 110k-token failure-day backlog, and the retry math
-      # diverges. Revert when chunked distillation lands.
-      sub_agents.max_iterations = 60;
+      # Chunked distillation (#47): bound each pass to a 10k-token
+      # slice so an oversized backlog drains across hourly passes
+      # instead of dying at the iteration cap and retrying forever.
+      memory.distill_slice_tokens = 10000;
 
       telegram = {
         enabled = true;

--- a/specs/21-memory.md
+++ b/specs/21-memory.md
@@ -132,13 +132,17 @@ reading session history through the context engine abstraction:
   **not** to the head — so history the budget could not reach this tick
   stays pending, not dropped. Between ticks a session can accumulate far
   more than the slice; the gate simply stays open and the next tick
-  folds the next slice. A backlog arbitrarily larger than one pass's
-  budget therefore distills completely across successive passes, the
-  cursor advancing per slice — a pass that fails retries its own slice
-  (watermarks move only on success) and never blocks later slices
-  beyond that retry. Bursty load drains on idle ticks. Sustained load
-  above one slice per tick lags without bound (nothing is lost, memory
-  just trails); draining the backlog within a tick is deferred
+  folds the next slice. Draining stops once the pending total falls
+  below the threshold — with a slice below the threshold, up to
+  `threshold - 1` tokens stay pending until new history reopens the
+  gate; a backlog drains to that floor, not to zero. A pass that fails
+  retries its own slice (watermarks move only on success); a transient
+  failure blocks later slices only until its retry succeeds, while a
+  deterministically failing slice (a fold that exceeds the iteration
+  cap, or poison content) blocks everything behind it — a known
+  residual. Bursty load drains on idle ticks. Sustained load above one
+  slice per tick lags without bound (nothing is lost, memory just
+  trails); draining the backlog within a tick is deferred
   ([FUTURE](FUTURE.md)).
 - **Duties:** extract durable facts from the new events into topics and
   index; merge and dedupe entries the in-turn writes accumulated; prune
@@ -245,7 +249,10 @@ not "no response".
   inside the distiller's window) is provisional; needs live
   token-volume data to confirm.
 - Large consolidated spans could approach the memory model's window at
-  very high thresholds. Resolved by `distill_slice_tokens` (#47): the
-  slice bounds each pass's span, and an oversized backlog drains
-  across successive gate-open passes instead of failing a single
-  oversized turn and retrying forever.
+  very high thresholds. Mitigated by `distill_slice_tokens` (#47): the
+  slice bounds each pass's span, so an oversized backlog drains across
+  successive gate-open passes instead of failing a single oversized
+  turn and retrying forever. The slice bounds spans, not atoms — a
+  single event larger than the slice is still folded whole (the
+  at-least-one-event clamp guarantees progress) and can fail the pass
+  on its own.

--- a/specs/21-memory.md
+++ b/specs/21-memory.md
@@ -113,28 +113,31 @@ reading session history through the context engine abstraction:
   sessions are weighed by their summed `token_count`, and distillation
   runs once that total crosses `distill_threshold_tokens`. Tokens, not
   a raw event count, because the binding constraint is the distiller's
-  context window: the threshold doubles as the shared token budget for
-  the consolidated span, so a triggered pass fits in one turn. Not
-  wall-clock either — an idle week burns nothing, a busy day may cross
-  the gate more than once. The watermark makes the probe a counting
-  query that never loads message bodies.
+  context window. Not wall-clock either — an idle week burns nothing,
+  a busy day may cross the gate more than once. The watermark makes
+  the probe a counting query that never loads message bodies.
 - **Execution:** one **consolidated** pass folds every session's pending
   span into a single distiller turn (cheapest, and it enables
   cross-session dedupe). It runs as a worker sub-agent on a fresh
   ephemeral context, never the root session — reading transcript spans
   is bulk work that must not evict real context. Uses the
   `provider.model_overrides.memory` role when configured. The spans
-  share one token budget seeded from the threshold; each fetch is
-  clamped to the remaining budget and still returns at least one event,
-  so an oversized head cannot stall progress.
+  share one token budget seeded from `distill_slice_tokens` (the
+  threshold when unset); each fetch is clamped to the remaining budget
+  and still returns at least one event, so an oversized head cannot
+  stall progress.
 - **Backlog carry:** exactly one pass runs per heartbeat tick, and it
-  reads at most one budget's worth. Each session's watermark advances by
+  reads at most one slice's worth. Each session's watermark advances by
   the events actually read (positions are dense, so `after + count`),
   **not** to the head — so history the budget could not reach this tick
   stays pending, not dropped. Between ticks a session can accumulate far
-  more than the budget; the gate simply stays open and the next tick
-  folds the next span. Bursty load drains on idle ticks. Sustained load
-  above one budget per tick lags without bound (nothing is lost, memory
+  more than the slice; the gate simply stays open and the next tick
+  folds the next slice. A backlog arbitrarily larger than one pass's
+  budget therefore distills completely across successive passes, the
+  cursor advancing per slice — a pass that fails retries its own slice
+  (watermarks move only on success) and never blocks later slices
+  beyond that retry. Bursty load drains on idle ticks. Sustained load
+  above one slice per tick lags without bound (nothing is lost, memory
   just trails); draining the backlog within a tick is deferred
   ([FUTURE](FUTURE.md)).
 - **Duties:** extract durable facts from the new events into topics and
@@ -222,7 +225,8 @@ not "no response".
 | Config key | Default | Description |
 |------------|---------|-------------|
 | `memory.index_cap_bytes` | 8192 | Injection truncation cap for MEMORY.md |
-| `memory.distill_threshold_tokens` | 40000 (provisional) | Undistilled-token total that opens the distillation gate, and the token budget for the consolidated span |
+| `memory.distill_threshold_tokens` | 40000 (provisional) | Undistilled-token total that opens the distillation gate |
+| `memory.distill_slice_tokens` | unset | Token budget for one pass's consolidated span; unset uses the threshold. Must be > 0 and <= the threshold |
 | `provider.model_overrides.memory` | unset | Model for the distillation pass (falls back to `provider.model`) |
 
 - The index is plain markdown, human-readable and human-editable; no
@@ -241,5 +245,7 @@ not "no response".
   inside the distiller's window) is provisional; needs live
   token-volume data to confirm.
 - Large consolidated spans could approach the memory model's window at
-  very high thresholds. The threshold bounds it in practice, so
-  chunking the span across turns is deferred, not built.
+  very high thresholds. Resolved by `distill_slice_tokens` (#47): the
+  slice bounds each pass's span, and an oversized backlog drains
+  across successive gate-open passes instead of failing a single
+  oversized turn and retrying forever.

--- a/src/config.rs
+++ b/src/config.rs
@@ -370,6 +370,13 @@ pub struct MemoryConfig {
     /// below the distiller's window so a triggered pass fits in one
     /// turn. Must be > 0.
     pub distill_threshold_tokens: u64,
+    /// Token budget for one distillation pass's consolidated span.
+    /// `None` (default) uses `distill_threshold_tokens`, so a pass
+    /// folds the whole gated backlog. `Some(n)` (must be > 0 and <=
+    /// the threshold) bounds each pass to one slice: a backlog too
+    /// large for one turn drains across successive gate-open ticks
+    /// instead of failing and retrying forever.
+    pub distill_slice_tokens: Option<u64>,
 }
 
 /// Telegram channel settings.
@@ -759,6 +766,7 @@ impl Default for MemoryConfig {
         Self {
             index_cap_bytes: 8192,
             distill_threshold_tokens: 40_000,
+            distill_slice_tokens: None,
         }
     }
 }
@@ -895,6 +903,13 @@ impl Config {
         if self.memory.distill_threshold_tokens == 0 {
             return Err(ConfigError::Invalid(
                 "memory distill_threshold_tokens must be > 0".into(),
+            ));
+        }
+        if let Some(slice) = self.memory.distill_slice_tokens
+            && (slice == 0 || slice > self.memory.distill_threshold_tokens)
+        {
+            return Err(ConfigError::Invalid(
+                "memory distill_slice_tokens must be > 0 and <= distill_threshold_tokens".into(),
             ));
         }
         if self.provider.max_tokens == 0 {
@@ -1390,14 +1405,19 @@ prompt = \"Review recent commits for security issues.\"
         let cfg = load_toml("").unwrap();
         assert_eq!(cfg.memory.index_cap_bytes, 8192);
         assert_eq!(cfg.memory.distill_threshold_tokens, 40_000);
+        assert_eq!(cfg.memory.distill_slice_tokens, None);
     }
 
     #[test]
     fn memory_parse() {
-        let cfg = load_toml("[memory]\nindex_cap_bytes = 4096\ndistill_threshold_tokens = 20000\n")
-            .unwrap();
+        let cfg = load_toml(
+            "[memory]\nindex_cap_bytes = 4096\ndistill_threshold_tokens = 20000\n\
+             distill_slice_tokens = 5000\n",
+        )
+        .unwrap();
         assert_eq!(cfg.memory.index_cap_bytes, 4096);
         assert_eq!(cfg.memory.distill_threshold_tokens, 20_000);
+        assert_eq!(cfg.memory.distill_slice_tokens, Some(5000));
     }
 
     #[test]
@@ -1410,6 +1430,26 @@ prompt = \"Review recent commits for security issues.\"
     fn memory_reject_zero_distill_threshold() {
         let result = load_toml("[memory]\ndistill_threshold_tokens = 0\n");
         assert!(matches!(result, Err(ConfigError::Invalid(_))));
+    }
+
+    #[test]
+    fn memory_reject_zero_slice() {
+        let result = load_toml("[memory]\ndistill_slice_tokens = 0\n");
+        assert!(matches!(result, Err(ConfigError::Invalid(_))));
+    }
+
+    #[test]
+    fn memory_reject_slice_above_threshold() {
+        let result =
+            load_toml("[memory]\ndistill_threshold_tokens = 20000\ndistill_slice_tokens = 20001\n");
+        assert!(matches!(result, Err(ConfigError::Invalid(_))));
+    }
+
+    #[test]
+    fn memory_accept_slice_at_threshold() {
+        let result =
+            load_toml("[memory]\ndistill_threshold_tokens = 20000\ndistill_slice_tokens = 20000\n");
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -383,6 +383,7 @@ fn spawn_with_engine<E: ContextEngine + 'static>(
         workspace.path(),
         state_db.clone(),
         config.memory.distill_threshold_tokens,
+        config.memory.distill_slice_tokens,
         config.sub_agents.max_iterations,
         config.memory.index_cap_bytes,
     ));

--- a/src/memory/distill.rs
+++ b/src/memory/distill.rs
@@ -104,17 +104,17 @@ const DISTILL_PROMPT: &str = include_str!("../prompts/distill.md");
 
 /// The distiller worker: a fixed system prompt plus the memory-editing
 /// tool set, mirroring the sub-agent construction in `agent::task`. It
-/// also carries the run knobs (the gate threshold and the tool-loop
-/// cap) since both are fixed properties of the distiller, not the call
-/// site.
+/// also carries the run knobs (the gate threshold, the per-pass slice
+/// budget, and the tool-loop cap) since all are fixed properties of
+/// the distiller, not the call site.
 pub struct Distiller {
     system_prompt: String,
     tools: Tools,
     threshold: u64,
-    /// Token budget for one pass's consolidated span: the slice
-    /// knob when set, else the threshold. Seeding the gather from
-    /// this rather than the threshold is what bounds a pass when
-    /// the backlog exceeds what one turn can fold.
+    /// Token budget for one pass's consolidated span. Defaults to the
+    /// threshold, so an unset slice folds the whole gated backlog in
+    /// one pass; a smaller value bounds each pass to one slice and an
+    /// oversized backlog drains across successive gate-open passes.
     slice_tokens: u64,
     max_iterations: usize,
     /// The injection cap for memory/MEMORY.md: the index is truncated
@@ -128,9 +128,6 @@ pub struct Distiller {
 impl Distiller {
     /// Build the distiller from the parent's base registry
     /// (post-`tools.disabled`), filtered to the memory-editing tools.
-    /// `slice_tokens` of `None` means one pass folds the whole gated
-    /// backlog (budget = threshold); `Some(n)` bounds each pass to one
-    /// slice so an oversized backlog drains across passes.
     pub fn new(
         base: &Tools,
         workspace_dir: &Path,
@@ -191,12 +188,11 @@ impl Distiller {
 /// Probes the per-session pending token totals, and if their sum has
 /// not reached the distiller's threshold, returns `Ok(None)` without an
 /// LLM call. Otherwise it gathers the pending spans across sessions
-/// (sharing one token budget — the slice, which defaults to the
-/// threshold — so the consolidated pass stays bounded), folds them into
-/// a single distiller turn on a fresh ephemeral context, and on success
-/// advances each session's watermark and persists the state. A failed
-/// turn leaves the watermarks untouched so the same span is retried at
-/// the next gate crossing.
+/// (sharing the distiller's slice budget so the consolidated pass stays
+/// bounded), folds them into a single distiller turn on a fresh
+/// ephemeral context, and on success advances each session's watermark
+/// and persists the state. A failed turn leaves the watermarks
+/// untouched so the same span is retried at the next gate crossing.
 ///
 /// Returns the pass summary paired with its billed [`TurnUsage`] so the
 /// caller can record the cost; `None` when the gate is closed.
@@ -220,9 +216,7 @@ pub async fn run<P: Provider, E: ContextEngine>(
 
     // Share one token budget across sessions so the consolidated span
     // cannot outgrow the distiller's window; each fetch is clamped and
-    // always makes progress. The budget is the slice, not the
-    // threshold, so a backlog larger than one pass drains slice by
-    // slice across gate-open ticks.
+    // always makes progress.
     let mut gathered = Gathered::new(distiller.slice_tokens);
     for name in pending.keys() {
         if gathered.budget == 0 {
@@ -1071,6 +1065,89 @@ mod run_tests {
         .unwrap();
         assert!(out.is_none());
         assert_eq!(provider.call_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn slice_below_threshold_bounds_first_pass() {
+        let (_dir, ws) = workspace();
+        // 1200 pending, threshold 1200, slice 400: the first pass must
+        // fold one 400-token slice, not the whole gated backlog — a
+        // threshold-seeded budget would fold all three sessions here.
+        let engine = FakeEngine {
+            pending: BTreeMap::new(),
+            transcripts: BTreeMap::from([
+                ("a".into(), session_messages(4, 100)),
+                ("b".into(), session_messages(4, 100)),
+                ("c".into(), session_messages(4, 100)),
+            ]),
+        };
+        let provider = Arc::new(MockProvider::new(vec![
+            Ok(Response::Text("pass 1".into())),
+            Ok(Response::Text("pass 2".into())),
+        ]));
+        let db = crate::state_db::StateDb::open_in_memory().unwrap();
+        let distiller = Distiller::new(&Tools::default(), ws.path(), db, 1200, Some(400), 5, 8192);
+        let mut state = DistillState::default();
+
+        let out = run(
+            &engine,
+            &distiller,
+            &*provider,
+            &noop_summarize(),
+            &ws,
+            &mut state,
+            Gate::Enforce,
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.expect("pass 1 runs").0, "pass 1");
+        assert_eq!(state.watermarks.get("a"), Some(&4));
+        assert!(!state.watermarks.contains_key("b"));
+        assert!(!state.watermarks.contains_key("c"));
+        assert_eq!(provider.call_count(), 1);
+
+        // 800 pending < 1200 threshold: the gate closes and the tail
+        // waits for new history — the floor of sliced draining.
+        let out = run(
+            &engine,
+            &distiller,
+            &*provider,
+            &noop_summarize(),
+            &ws,
+            &mut state,
+            Gate::Enforce,
+        )
+        .await
+        .unwrap();
+        assert!(out.is_none());
+        assert_eq!(provider.call_count(), 1);
+
+        // New history reopens the gate (1300 >= 1200) and the next
+        // pass folds the next slice.
+        let engine = FakeEngine {
+            pending: BTreeMap::new(),
+            transcripts: BTreeMap::from([
+                ("a".into(), session_messages(4, 100)),
+                ("b".into(), session_messages(4, 100)),
+                ("c".into(), session_messages(4, 100)),
+                ("d".into(), session_messages(5, 100)),
+            ]),
+        };
+        let out = run(
+            &engine,
+            &distiller,
+            &*provider,
+            &noop_summarize(),
+            &ws,
+            &mut state,
+            Gate::Enforce,
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.expect("pass 2 runs").0, "pass 2");
+        assert_eq!(state.watermarks.get("b"), Some(&4));
+        assert!(!state.watermarks.contains_key("c"));
+        assert_eq!(provider.call_count(), 2);
     }
 
     #[tokio::test]

--- a/src/memory/distill.rs
+++ b/src/memory/distill.rs
@@ -111,6 +111,11 @@ pub struct Distiller {
     system_prompt: String,
     tools: Tools,
     threshold: u64,
+    /// Token budget for one pass's consolidated span: the slice
+    /// knob when set, else the threshold. Seeding the gather from
+    /// this rather than the threshold is what bounds a pass when
+    /// the backlog exceeds what one turn can fold.
+    slice_tokens: u64,
     max_iterations: usize,
     /// The injection cap for memory/MEMORY.md: the index is truncated
     /// past this at prompt time, so the distiller must keep it under.
@@ -123,11 +128,15 @@ pub struct Distiller {
 impl Distiller {
     /// Build the distiller from the parent's base registry
     /// (post-`tools.disabled`), filtered to the memory-editing tools.
+    /// `slice_tokens` of `None` means one pass folds the whole gated
+    /// backlog (budget = threshold); `Some(n)` bounds each pass to one
+    /// slice so an oversized backlog drains across passes.
     pub fn new(
         base: &Tools,
         workspace_dir: &Path,
         state_db: StateDb,
         threshold: u64,
+        slice_tokens: Option<u64>,
         max_iterations: usize,
         index_cap_bytes: usize,
     ) -> Self {
@@ -147,6 +156,7 @@ impl Distiller {
             system_prompt,
             tools,
             threshold,
+            slice_tokens: slice_tokens.unwrap_or(threshold),
             max_iterations,
             index_cap_bytes,
             state_db,
@@ -181,11 +191,12 @@ impl Distiller {
 /// Probes the per-session pending token totals, and if their sum has
 /// not reached the distiller's threshold, returns `Ok(None)` without an
 /// LLM call. Otherwise it gathers the pending spans across sessions
-/// (sharing one token budget so the consolidated pass stays bounded),
-/// folds them into a single distiller turn on a fresh ephemeral
-/// context, and on success advances each session's watermark and
-/// persists the state. A failed turn leaves the watermarks untouched so
-/// the same span is retried at the next gate crossing.
+/// (sharing one token budget — the slice, which defaults to the
+/// threshold — so the consolidated pass stays bounded), folds them into
+/// a single distiller turn on a fresh ephemeral context, and on success
+/// advances each session's watermark and persists the state. A failed
+/// turn leaves the watermarks untouched so the same span is retried at
+/// the next gate crossing.
 ///
 /// Returns the pass summary paired with its billed [`TurnUsage`] so the
 /// caller can record the cost; `None` when the gate is closed.
@@ -209,8 +220,10 @@ pub async fn run<P: Provider, E: ContextEngine>(
 
     // Share one token budget across sessions so the consolidated span
     // cannot outgrow the distiller's window; each fetch is clamped and
-    // always makes progress.
-    let mut gathered = Gathered::new(distiller.threshold);
+    // always makes progress. The budget is the slice, not the
+    // threshold, so a backlog larger than one pass drains slice by
+    // slice across gate-open ticks.
+    let mut gathered = Gathered::new(distiller.slice_tokens);
     for name in pending.keys() {
         if gathered.budget == 0 {
             break;
@@ -496,9 +509,28 @@ mod run_tests {
     impl ContextEngine for FakeEngine {
         async fn pending_distill_tokens(
             &self,
-            _since: &BTreeMap<String, u64>,
+            since: &BTreeMap<String, u64>,
         ) -> Result<BTreeMap<String, u64>, EngineError> {
-            Ok(self.pending.clone())
+            // A static pending map overrides the computed one, so tests
+            // that control the gate independently of transcript size
+            // keep working.
+            if !self.pending.is_empty() {
+                return Ok(self.pending.clone());
+            }
+            let mut out = BTreeMap::new();
+            for (name, msgs) in &self.transcripts {
+                let after = usize::try_from(since.get(name).copied().unwrap_or(0)).unwrap_or(0);
+                let total: u64 = msgs
+                    .get(after..)
+                    .unwrap_or(&[])
+                    .iter()
+                    .map(|m| u64::try_from(m.token_estimate()).unwrap_or(0))
+                    .sum();
+                if total > 0 {
+                    out.insert(name.clone(), total);
+                }
+            }
+            Ok(out)
         }
 
         fn backup(
@@ -520,10 +552,24 @@ mod run_tests {
         async fn transcript_since(
             &self,
             session: &str,
-            _after: u64,
-            _max_tokens: u64,
+            after: u64,
+            max_tokens: u64,
         ) -> Result<Vec<Message>, EngineError> {
-            Ok(self.transcripts.get(session).cloned().unwrap_or_default())
+            let Some(msgs) = self.transcripts.get(session) else {
+                return Ok(Vec::new());
+            };
+            let after = usize::try_from(after).unwrap_or(0);
+            let mut out = Vec::new();
+            let mut total: u64 = 0;
+            for msg in msgs.get(after..).unwrap_or(&[]) {
+                let tokens = u64::try_from(msg.token_estimate()).unwrap_or(u64::MAX);
+                if !out.is_empty() && total + tokens > max_tokens {
+                    break;
+                }
+                out.push(msg.clone());
+                total += tokens;
+            }
+            Ok(out)
         }
 
         async fn push_message(&mut self, _msg: Message) -> Result<(), EngineError> {
@@ -589,7 +635,15 @@ mod run_tests {
         };
         let provider = Arc::new(MockProvider::new(vec![]));
         let db = crate::state_db::StateDb::open_in_memory().unwrap();
-        let distiller = Distiller::new(&Tools::default(), ws.path(), db.clone(), 1000, 5, 8192);
+        let distiller = Distiller::new(
+            &Tools::default(),
+            ws.path(),
+            db.clone(),
+            1000,
+            None,
+            5,
+            8192,
+        );
         let mut state = DistillState::default();
 
         let out = run(
@@ -626,7 +680,15 @@ mod run_tests {
             "forced pass".into(),
         ))]));
         let db = crate::state_db::StateDb::open_in_memory().unwrap();
-        let distiller = Distiller::new(&Tools::default(), ws.path(), db.clone(), 1000, 5, 8192);
+        let distiller = Distiller::new(
+            &Tools::default(),
+            ws.path(),
+            db.clone(),
+            1000,
+            None,
+            5,
+            8192,
+        );
         let mut state = DistillState::default();
 
         let out = run(
@@ -665,7 +727,15 @@ mod run_tests {
             "did not compact".into(),
         ))]));
         let db = crate::state_db::StateDb::open_in_memory().unwrap();
-        let distiller = Distiller::new(&Tools::default(), ws.path(), db.clone(), 1000, 5, 8192);
+        let distiller = Distiller::new(
+            &Tools::default(),
+            ws.path(),
+            db.clone(),
+            1000,
+            None,
+            5,
+            8192,
+        );
         let mut state = DistillState::default();
 
         let out = run(
@@ -716,7 +786,15 @@ mod run_tests {
         };
         let provider = Arc::new(MockProvider::new(vec![]));
         let db = crate::state_db::StateDb::open_in_memory().unwrap();
-        let distiller = Distiller::new(&Tools::default(), ws.path(), db.clone(), 1000, 5, 8192);
+        let distiller = Distiller::new(
+            &Tools::default(),
+            ws.path(),
+            db.clone(),
+            1000,
+            None,
+            5,
+            8192,
+        );
         let mut state = DistillState::default();
 
         let out = run(
@@ -754,7 +832,15 @@ mod run_tests {
             "wrote canary fact".into(),
         ))]));
         let db = crate::state_db::StateDb::open_in_memory().unwrap();
-        let distiller = Distiller::new(&Tools::default(), ws.path(), db.clone(), 1000, 5, 8192);
+        let distiller = Distiller::new(
+            &Tools::default(),
+            ws.path(),
+            db.clone(),
+            1000,
+            None,
+            5,
+            8192,
+        );
         let mut state = DistillState::default();
 
         let out = run(
@@ -799,7 +885,15 @@ mod run_tests {
         };
         let provider = Arc::new(MockProvider::new(vec![]));
         let db = crate::state_db::StateDb::open_in_memory().unwrap();
-        let distiller = Distiller::new(&Tools::default(), ws.path(), db.clone(), 1000, 5, 8192);
+        let distiller = Distiller::new(
+            &Tools::default(),
+            ws.path(),
+            db.clone(),
+            1000,
+            None,
+            5,
+            8192,
+        );
 
         let state = distiller.load_state(&engine).await.unwrap();
 
@@ -828,7 +922,15 @@ mod run_tests {
             )]),
         };
         let db = crate::state_db::StateDb::open_in_memory().unwrap();
-        let distiller = Distiller::new(&Tools::default(), ws.path(), db.clone(), 1000, 5, 8192);
+        let distiller = Distiller::new(
+            &Tools::default(),
+            ws.path(),
+            db.clone(),
+            1000,
+            None,
+            5,
+            8192,
+        );
 
         let first = distiller.load_state(&engine).await.unwrap();
         // New history arrives after priming; a reload must keep the
@@ -851,7 +953,15 @@ mod run_tests {
         };
         let provider = Arc::new(MockProvider::new(vec![Err(ProviderError::RateLimited)]));
         let db = crate::state_db::StateDb::open_in_memory().unwrap();
-        let distiller = Distiller::new(&Tools::default(), ws.path(), db.clone(), 1000, 5, 8192);
+        let distiller = Distiller::new(
+            &Tools::default(),
+            ws.path(),
+            db.clone(),
+            1000,
+            None,
+            5,
+            8192,
+        );
         let mut state = DistillState::default();
 
         let result = run(
@@ -868,5 +978,169 @@ mod run_tests {
         assert!(result.is_err());
         assert!(state.watermarks.is_empty());
         assert!(db.get_doc("distillation").unwrap().is_none());
+    }
+
+    /// `n` user messages of `tokens` estimated tokens each.
+    fn session_messages(n: usize, tokens: usize) -> Vec<Message> {
+        (0..n)
+            .map(|_| Message::User {
+                content: "x".repeat(tokens * 4),
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn oversized_backlog_drains_across_passes() {
+        let (_dir, ws) = workspace();
+        // Three sessions of 400 tokens each: 1200 pending against a
+        // 400-token slice, so each pass folds exactly one session and
+        // the gate (threshold 400) stays open until the backlog is
+        // gone. A single-threshold pass would have to fold all 1200.
+        let engine = FakeEngine {
+            pending: BTreeMap::new(),
+            transcripts: BTreeMap::from([
+                ("a".into(), session_messages(4, 100)),
+                ("b".into(), session_messages(4, 100)),
+                ("c".into(), session_messages(4, 100)),
+            ]),
+        };
+        let provider = Arc::new(MockProvider::new(vec![
+            Ok(Response::Text("pass 1".into())),
+            Ok(Response::Text("pass 2".into())),
+            Ok(Response::Text("pass 3".into())),
+        ]));
+        let db = crate::state_db::StateDb::open_in_memory().unwrap();
+        let distiller = Distiller::new(&Tools::default(), ws.path(), db, 400, Some(400), 5, 8192);
+        let mut state = DistillState::default();
+
+        let out = run(
+            &engine,
+            &distiller,
+            &*provider,
+            &noop_summarize(),
+            &ws,
+            &mut state,
+            Gate::Enforce,
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.expect("pass 1 runs").0, "pass 1");
+        assert_eq!(state.watermarks.get("a"), Some(&4));
+        assert!(!state.watermarks.contains_key("b"));
+
+        let out = run(
+            &engine,
+            &distiller,
+            &*provider,
+            &noop_summarize(),
+            &ws,
+            &mut state,
+            Gate::Enforce,
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.expect("pass 2 runs").0, "pass 2");
+        assert_eq!(state.watermarks.get("b"), Some(&4));
+        assert!(!state.watermarks.contains_key("c"));
+
+        let out = run(
+            &engine,
+            &distiller,
+            &*provider,
+            &noop_summarize(),
+            &ws,
+            &mut state,
+            Gate::Enforce,
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.expect("pass 3 runs").0, "pass 3");
+        assert_eq!(state.watermarks.get("c"), Some(&4));
+
+        // Backlog drained: the gate closes and no fourth call happens.
+        let out = run(
+            &engine,
+            &distiller,
+            &*provider,
+            &noop_summarize(),
+            &ws,
+            &mut state,
+            Gate::Enforce,
+        )
+        .await
+        .unwrap();
+        assert!(out.is_none());
+        assert_eq!(provider.call_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn failed_slice_retries_then_later_slices_proceed() {
+        let (_dir, ws) = workspace();
+        // Two sessions of 400 tokens each, slice 400: one session per
+        // pass. The first pass fails, so its watermarks stay put and
+        // the same slice is retried; once it succeeds the next pass
+        // proceeds to the later session. A failed slice never advances
+        // the cursor past undistilled history.
+        let engine = FakeEngine {
+            pending: BTreeMap::new(),
+            transcripts: BTreeMap::from([
+                ("a".into(), session_messages(4, 100)),
+                ("b".into(), session_messages(4, 100)),
+            ]),
+        };
+        let provider = Arc::new(MockProvider::new(vec![
+            Err(ProviderError::RateLimited),
+            Ok(Response::Text("pass 2".into())),
+            Ok(Response::Text("pass 3".into())),
+        ]));
+        let db = crate::state_db::StateDb::open_in_memory().unwrap();
+        let distiller = Distiller::new(&Tools::default(), ws.path(), db, 400, Some(400), 5, 8192);
+        let mut state = DistillState::default();
+
+        // Pass 1 fails: no watermark moves, nothing persisted.
+        let result = run(
+            &engine,
+            &distiller,
+            &*provider,
+            &noop_summarize(),
+            &ws,
+            &mut state,
+            Gate::Enforce,
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(state.watermarks.is_empty());
+
+        // Pass 2 retries the same slice and succeeds.
+        let out = run(
+            &engine,
+            &distiller,
+            &*provider,
+            &noop_summarize(),
+            &ws,
+            &mut state,
+            Gate::Enforce,
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.expect("retry succeeds").0, "pass 2");
+        assert_eq!(state.watermarks.get("a"), Some(&4));
+        assert!(!state.watermarks.contains_key("b"));
+
+        // Pass 3 proceeds to the later slice.
+        let out = run(
+            &engine,
+            &distiller,
+            &*provider,
+            &noop_summarize(),
+            &ws,
+            &mut state,
+            Gate::Enforce,
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.expect("later slice proceeds").0, "pass 3");
+        assert_eq!(state.watermarks.get("b"), Some(&4));
+        assert_eq!(provider.call_count(), 3);
     }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -85,6 +85,7 @@ impl TestAgent {
             self.ws.path(),
             crate::state_db::StateDb::open_in_memory().unwrap(),
             40_000,
+            None,
             1,
             8192,
         ));


### PR DESCRIPTION
Closes #47

## What

Chunked distillation: each pass's consolidated span is bounded by a new `memory.distill_slice_tokens` budget (default unset = the threshold), instead of always gathering a threshold-sized span. A backlog larger than one pass now drains slice by slice across successive gate-open ticks.

## Why

The hourly distill pass died at the sub-agent iteration cap (30) against a ~110k-token backlog, and backlog-carry made that divergent: watermarks only advance on success, so a delta that does not fit one pass retried hourly forever at real cost ($0.46/pass observed). The deploy config's `sub_agents.max_iterations = 60` bump was a workaround; this is the fix, and the bump is reverted here.

## How

- `memory.distill_slice_tokens: Option<u64>` — `None` (default) uses `distill_threshold_tokens`, so default behavior is unchanged. `Some(n)` must be > 0 and <= the threshold; the validation makes `slice > threshold` unrepresentable (that was the bug's exact shape — a 0-sentinel would have allowed it).
- `Distiller` seeds its gather budget from the slice; the gate still keys on the threshold. Gather loop, watermark advance (`after + count`), and failure semantics (watermarks move only on success) are unchanged.
- Deploy config: revert `sub_agents.max_iterations` to the default 30 and set `distill_slice_tokens = 10000` — with the default slice (40k) the reverted cap would recreate the incident configuration.
- Spec 21: execution budget, backlog-carry per-slice drain and retry semantics, config table row, chunking open question resolved. README sample updated.

## Tests

- `oversized_backlog_drains_across_passes`: 3 sessions x 400 tokens against a 400-token slice — one session distilled per pass, gate stays open until drained, no fourth LLM call.
- `failed_slice_retries_then_later_slices_proceed`: a failed pass moves no watermark; the same slice retries, then later slices proceed.
- FakeEngine now honors `after`/`max_tokens` in `transcript_since` and computes pending tokens from transcripts, so the drain tests exercise real watermark arithmetic (matching the clamp-and-progress shape of both real engines).
- Config validation tests: zero slice, slice above threshold rejected; slice at threshold accepted.

Full `just check` (nix flake check, nixfmt/statix/deadnix, cargo deny) passed on both commits; fmt/clippy clean; affected test modules pass (memory 26, config 88, commands 9, agent 99). Full local `cargo test` times out in this environment (known); the nix test check in the gate ran the suite.

## Known residual (pre-existing, out of scope)

A single event larger than the slice still rides the >=1-event progress guarantee into an oversized turn, and a permanently failing head slice blocks later slices until it succeeds — the acceptance criterion's "beyond the next retry" holds for transient failures. Both were true before this change.