### PR TITLE
Park leftover work before the checkout reset

### DIFF
--- a/specs/25-github-issues.md
+++ b/specs/25-github-issues.md
@@ -67,7 +67,11 @@ notification, since GitHub sends none for edits. Ids are pruned with
 their issues; state predating the field falls back to
 reply-with-full-plan. Execution turns
 get a fresh base checkout prepared at `projects/<owner>/<repo>`
-(shared `execution_checkout` logic). The branch convention is
+(shared `execution_checkout` logic). The reset preserves before it
+destroys: a predecessor turn's uncommitted changes or stranded
+detached-HEAD commits are parked on a `kitaebot_recovered/<epoch>`
+branch, named in the turn's ready note, before the checkout is
+force-detached and cleaned. The branch convention is
 `kitaebot_issue-{n}_<summary>` and the PR description carries
 `Closes #{n}`, so merging the PR closes the ticket — GitHub issues
 have no workflow states to move, and no state tool exists.

--- a/src/channel/execution_checkout.rs
+++ b/src/channel/execution_checkout.rs
@@ -6,6 +6,14 @@
 //! is dispatched, the checkout is fetched and force-detached at the
 //! remote's default branch, then cleaned, so a stale clone from an
 //! earlier turn can never seed the branch with an outdated base.
+//!
+//! Preserve, then reset: a predecessor turn that died mid-work leaves
+//! a dirty tree or commits stranded on a detached HEAD, and the reset
+//! would destroy them. Leftovers are parked on a `kitaebot_recovered/`
+//! branch first; the ready note names it so the successor can decide
+//! what the work is worth.
+
+use std::path::Path;
 
 use crate::error::ToolError;
 use crate::tools::git::GitCli;
@@ -14,12 +22,34 @@ use crate::tools::git::checkout;
 /// Guidance when no fresh checkout could be prepared for the agent.
 pub(crate) const CLONE_YOURSELF: &str = "Clone or update the repo yourself before branching.";
 
-/// Describe a prepared checkout for the agent.
-pub(crate) fn ready_note(rel: &str) -> String {
-    format!(
-        "A fresh checkout at the default branch is ready at {rel} \
-         (use working_dir: \"{rel}\"). Branch from there; do not clone."
-    )
+/// A checkout [`prepare`] made ready for an execution turn.
+pub(crate) struct Prepared {
+    /// Workspace-relative checkout directory.
+    pub(crate) rel: String,
+    /// Branch holding a predecessor's parked leftovers, when any.
+    pub(crate) parked: Option<String>,
+}
+
+impl Prepared {
+    /// Describe the prepared checkout for the agent.
+    pub(crate) fn ready_note(&self) -> String {
+        use std::fmt::Write as _;
+
+        let mut note = format!(
+            "A fresh checkout at the default branch is ready at {} \
+             (use working_dir: \"{}\"). Branch from there; do not clone.",
+            self.rel, self.rel,
+        );
+        if let Some(parked) = &self.parked {
+            let _ = write!(
+                note,
+                " A previous turn left unfinished work, parked on branch \
+                 {parked}: inspect it before starting (git log/diff \
+                 origin/HEAD..{parked}) and salvage or ignore it."
+            );
+        }
+        note
+    }
 }
 
 /// Workspace-relative checkout directory for `owner/repo`.
@@ -27,24 +57,34 @@ pub(crate) fn checkout_rel_path(nwo: &str) -> Result<String, ToolError> {
     checkout::rel_path("projects", nwo)
 }
 
-/// Clone the repo if needed, fetch, force-detach at the remote's default
-/// branch, and drop any leftover files.
-///
-/// Returns the workspace-relative checkout path.
-pub(crate) async fn prepare(git: &GitCli, nwo: &str) -> Result<String, ToolError> {
+/// Clone the repo if needed, park a predecessor's leftovers, fetch,
+/// force-detach at the remote's default branch, and drop any leftover
+/// files.
+pub(crate) async fn prepare(git: &GitCli, nwo: &str) -> Result<Prepared, ToolError> {
     let rel = checkout_rel_path(nwo)?;
     let url = git.repo_url(nwo);
-    prepare_at(git, &url, &rel).await?;
-    Ok(rel)
+    let parked = prepare_at(git, &url, &rel).await?;
+    Ok(Prepared { rel, parked })
 }
 
 /// In-repo caches the per-turn clean must not touch: re-provisioning
 /// them costs far more than tolerating a stale entry.
 const KEPT_CACHES: &[&str] = &[".direnv", ".gcroots", "node_modules", ".venv"];
 
+/// Branch prefix for parked leftovers. Epoch-suffixed, so repeated
+/// interruptions never collide.
+const RECOVERED_PREFIX: &str = "kitaebot_recovered/";
+
 /// URL-parametrized body of [`prepare`], so tests can use `file://`.
-async fn prepare_at(git: &GitCli, url: &str, rel: &str) -> Result<(), ToolError> {
-    let dir = checkout::ensure_cloned(git, url, rel).await?.into_dir();
+async fn prepare_at(git: &GitCli, url: &str, rel: &str) -> Result<Option<String>, ToolError> {
+    let (dir, parked) = match checkout::ensure_cloned(git, url, rel).await? {
+        // A fresh clone has nothing to lose.
+        checkout::Ensured::Cloned(dir) => (dir, None),
+        checkout::Ensured::Existing(dir) => {
+            let parked = park_leftovers(git, &dir).await?;
+            (dir, parked)
+        }
+    };
     checkout::run(git, &["fetch", "origin"], &dir, true).await?;
     checkout::run(
         git,
@@ -62,7 +102,76 @@ async fn prepare_at(git: &GitCli, url: &str, rel: &str) -> Result<(), ToolError>
     // Provision the devShell (trust + dependency install) before the
     // turn starts, so exec finds a working toolchain immediately.
     git.warm_devshell(&dir).await;
-    Ok(())
+    Ok(parked)
+}
+
+/// Park a predecessor's leftovers on a branch before the reset
+/// destroys them: uncommitted changes are committed there, and
+/// commits stranded on a detached HEAD get a name that survives the
+/// re-detach. Returns the branch name when anything was parked.
+///
+/// The kept caches are excluded from the parked commit: committing
+/// them would make the later tree-switch delete them from the
+/// worktree, defeating the exclusions the clean honors.
+async fn park_leftovers(git: &GitCli, dir: &Path) -> Result<Option<String>, ToolError> {
+    let mut pathspec = vec![".".to_string()];
+    pathspec.extend(KEPT_CACHES.iter().map(|c| format!(":(exclude){c}")));
+    let pathspec: Vec<&str> = pathspec.iter().map(String::as_str).collect();
+
+    let mut status = vec!["status", "--porcelain", "--"];
+    status.extend(&pathspec);
+    let (_, dirty) = checkout::run_read(git, &status, dir).await?;
+    let dirty = !dirty.trim().is_empty();
+    // Only a detached HEAD strands commits — a branch-attached HEAD
+    // (the normal state after a successful turn) keeps its own.
+    // symbolic-ref exits non-zero when detached.
+    let (attached, _) = checkout::run_read(git, &["symbolic-ref", "-q", "HEAD"], dir).await?;
+    let stranded = if attached == 0 {
+        false
+    } else {
+        // Exit 0 = HEAD reachable from origin/HEAD = nothing to lose.
+        let (ancestor, _) = checkout::run_read(
+            git,
+            &["merge-base", "--is-ancestor", "HEAD", "origin/HEAD"],
+            dir,
+        )
+        .await?;
+        ancestor != 0
+    };
+    if !dirty && !stranded {
+        return Ok(None);
+    }
+
+    let name = format!("{RECOVERED_PREFIX}{}", crate::time::now_epoch());
+    checkout::run(git, &["checkout", "-b", &name], dir, false).await?;
+    if dirty {
+        let mut add = vec!["add", "-A", "--"];
+        add.extend(&pathspec);
+        checkout::run(git, &add, dir, false).await?;
+        // Hermetic identity, unsigned, hook-free: this is a checkpoint
+        // of a possibly-broken tree, and a pre-commit hook that gates
+        // on that tree would abort the very rescue it needs.
+        checkout::run(
+            git,
+            &[
+                "-c",
+                "user.name=kitaebot",
+                "-c",
+                "user.email=kitaebot@localhost",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--no-verify",
+                "--allow-empty",
+                "-m",
+                "Park leftover work from an interrupted turn",
+            ],
+            dir,
+            false,
+        )
+        .await?;
+    }
+    Ok(Some(name))
 }
 
 #[cfg(test)]
@@ -82,6 +191,25 @@ mod tests {
         assert_eq!(
             checkout_rel_path("owner/repo").unwrap(),
             "projects/owner/repo"
+        );
+    }
+
+    #[test]
+    fn ready_note_names_the_parked_branch_only_when_present() {
+        let clean = Prepared {
+            rel: "projects/o/r".into(),
+            parked: None,
+        };
+        assert!(!clean.ready_note().contains("parked"));
+        let parked = Prepared {
+            rel: "projects/o/r".into(),
+            parked: Some("kitaebot_recovered/123".into()),
+        };
+        let note = parked.ready_note();
+        assert!(note.contains("kitaebot_recovered/123"), "{note}");
+        assert!(
+            note.contains("origin/HEAD..kitaebot_recovered/123"),
+            "{note}"
         );
     }
 
@@ -151,7 +279,13 @@ mod tests {
         );
         let url = format!("file://{}", origin.path().display());
 
-        prepare_at(&git, &url, "projects/o/r").await.unwrap();
+        assert!(
+            prepare_at(&git, &url, "projects/o/r")
+                .await
+                .unwrap()
+                .is_none(),
+            "fresh clone parks nothing"
+        );
 
         // A previous turn left the checkout dirty (tracked edit plus an
         // untracked file); the base advanced.
@@ -164,7 +298,10 @@ mod tests {
             .trim()
             .to_string();
 
-        prepare_at(&git, &url, "projects/o/r").await.unwrap();
+        let parked = prepare_at(&git, &url, "projects/o/r")
+            .await
+            .unwrap()
+            .expect("dirty tree must be parked");
 
         assert_eq!(git_in(&checkout, &["rev-parse", "HEAD"]).trim(), sha2);
         assert_eq!(
@@ -172,6 +309,108 @@ mod tests {
             "base v2\n"
         );
         assert!(!checkout.join("leftover.txt").exists());
+        // The parked branch holds both the tracked edit and the
+        // untracked file.
+        let files = git_in(&checkout, &["show", "--stat", "--format=", &parked]);
+        assert!(files.contains("a.txt"), "{files}");
+        assert!(files.contains("leftover.txt"), "{files}");
+        let content = git_in(&checkout, &["show", &format!("{parked}:a.txt")]);
+        assert_eq!(content, "local damage\n");
+    }
+
+    #[tokio::test]
+    async fn prepare_parks_nothing_on_a_clean_reused_checkout() {
+        let workspace = tempfile::tempdir().unwrap();
+        let origin = tempfile::tempdir().unwrap();
+        fixture_origin(origin.path());
+        let git = GitCli::new(
+            Secret::test("fake"),
+            workspace.path(),
+            DirenvCache::new(),
+            Vec::new(),
+        );
+        let url = format!("file://{}", origin.path().display());
+
+        prepare_at(&git, &url, "projects/o/r").await.unwrap();
+        assert!(
+            prepare_at(&git, &url, "projects/o/r")
+                .await
+                .unwrap()
+                .is_none(),
+            "clean reuse parks nothing"
+        );
+        let checkout = workspace.path().join("projects/o/r");
+        let branches = git_in(&checkout, &["branch", "--list", "kitaebot_recovered/*"]);
+        assert!(branches.trim().is_empty(), "{branches}");
+    }
+
+    #[tokio::test]
+    async fn prepare_parks_nothing_after_a_successful_turn_on_a_branch() {
+        let workspace = tempfile::tempdir().unwrap();
+        let origin = tempfile::tempdir().unwrap();
+        fixture_origin(origin.path());
+        let git = GitCli::new(
+            Secret::test("fake"),
+            workspace.path(),
+            DirenvCache::new(),
+            Vec::new(),
+        );
+        let url = format!("file://{}", origin.path().display());
+        prepare_at(&git, &url, "projects/o/r").await.unwrap();
+
+        // A successful turn's end state: clean tree, HEAD attached to
+        // the work branch it pushed, ahead of origin/HEAD. The branch
+        // keeps its own commits; nothing is stranded.
+        let checkout = workspace.path().join("projects/o/r");
+        git_in(&checkout, &["checkout", "-b", "kitaebot_issue-9_fix"]);
+        std::fs::write(checkout.join("fix.rs"), "fn fix() {}\n").unwrap();
+        git_in(&checkout, &["add", "fix.rs"]);
+        git_in(&checkout, &["commit", "-m", "fix"]);
+
+        assert!(
+            prepare_at(&git, &url, "projects/o/r")
+                .await
+                .unwrap()
+                .is_none(),
+            "a branch-attached HEAD must not be parked"
+        );
+        let branches = git_in(&checkout, &["branch", "--list", "kitaebot_recovered/*"]);
+        assert!(branches.trim().is_empty(), "{branches}");
+        // The work branch itself survives untouched.
+        let sha = git_in(&checkout, &["rev-parse", "kitaebot_issue-9_fix"]);
+        assert!(!sha.trim().is_empty());
+    }
+
+    #[tokio::test]
+    async fn prepare_parks_commits_stranded_on_a_detached_head() {
+        let workspace = tempfile::tempdir().unwrap();
+        let origin = tempfile::tempdir().unwrap();
+        fixture_origin(origin.path());
+        let git = GitCli::new(
+            Secret::test("fake"),
+            workspace.path(),
+            DirenvCache::new(),
+            Vec::new(),
+        );
+        let url = format!("file://{}", origin.path().display());
+        prepare_at(&git, &url, "projects/o/r").await.unwrap();
+
+        // A previous turn committed on the detached HEAD and died
+        // before pushing or branching; the tree is clean.
+        let checkout = workspace.path().join("projects/o/r");
+        std::fs::write(checkout.join("wip.rs"), "fn wip() {}\n").unwrap();
+        git_in(&checkout, &["add", "wip.rs"]);
+        git_in(&checkout, &["commit", "-m", "wip"]);
+        let stranded = git_in(&checkout, &["rev-parse", "HEAD"]).trim().to_string();
+
+        let parked = prepare_at(&git, &url, "projects/o/r")
+            .await
+            .unwrap()
+            .expect("stranded commit must be parked");
+
+        // The branch names the stranded commit; HEAD is back on base.
+        assert_eq!(git_in(&checkout, &["rev-parse", &parked]).trim(), stranded);
+        assert!(!checkout.join("wip.rs").exists());
     }
 
     #[tokio::test]
@@ -201,7 +440,16 @@ mod tests {
         std::fs::write(checkout.join("target/lib.rlib"), "cached\n").unwrap();
         std::fs::write(checkout.join("stale.log"), "junk\n").unwrap();
 
-        prepare_at(&git, &url, "projects/o/r").await.unwrap();
+        let parked = prepare_at(&git, &url, "projects/o/r")
+            .await
+            .unwrap()
+            .expect("stale.log and target are parked as leftovers");
+        // The kept caches must stay out of the parked commit: tracked
+        // cache files would be deleted from the worktree by the
+        // tree-switch back to base.
+        let files = git_in(&checkout, &["show", "--stat", "--format=", &parked]);
+        assert!(!files.contains("node_modules"), "{files}");
+        assert!(!files.contains(".gcroots"), "{files}");
 
         assert!(
             checkout.join("node_modules/dep.js").exists(),

--- a/src/channel/github/issues.rs
+++ b/src/channel/github/issues.rs
@@ -159,7 +159,7 @@ async fn checkout_note(git: &GitCli, d: &Dispatch) -> Option<String> {
         return None;
     }
     match execution_checkout::prepare(git, &d.nwo).await {
-        Ok(rel) => Some(execution_checkout::ready_note(&rel)),
+        Ok(prepared) => Some(prepared.ready_note()),
         Err(e) => {
             warn!(issue = %d.key, "execution checkout prep failed: {e}");
             Some(execution_checkout::CLONE_YOURSELF.into())

--- a/src/channel/linear.rs
+++ b/src/channel/linear.rs
@@ -159,7 +159,7 @@ async fn checkout_note(channel: &LinearChannel, d: &Dispatch) -> Option<String> 
         return Some(execution_checkout::CLONE_YOURSELF.into());
     };
     match execution_checkout::prepare(git, &d.repo).await {
-        Ok(rel) => Some(execution_checkout::ready_note(&rel)),
+        Ok(prepared) => Some(prepared.ready_note()),
         Err(e) => {
             warn!(identifier = %d.identifier, "execution checkout prep failed: {e}");
             Some(execution_checkout::CLONE_YOURSELF.into())

--- a/src/config.rs
+++ b/src/config.rs
@@ -972,37 +972,7 @@ impl Config {
                 "temperature must be between 0.0 and 2.0".into(),
             ));
         }
-        for (role, spec) in self.provider.model_overrides.iter() {
-            if spec.model.is_none() && spec.reasoning.is_none() {
-                return Err(ConfigError::Invalid(format!(
-                    "model_overrides.{role} is empty: set model, reasoning, or both"
-                )));
-            }
-        }
-        let role_reasonings = self
-            .provider
-            .model_overrides
-            .iter()
-            .map(|(role, spec)| (role, spec.reasoning));
-        for (name, reasoning) in std::iter::once(("provider", self.provider.reasoning))
-            .chain(role_reasonings)
-            .filter_map(|(name, r)| r.map(|r| (name, r)))
-        {
-            if !matches!(self.provider.api, Api::OpenRouter) {
-                return Err(ConfigError::Invalid(format!(
-                    "{name} reasoning requires the openrouter api"
-                )));
-            }
-            if let Reasoning::MaxTokens(cap) = reasoning
-                && (cap == 0 || cap >= self.provider.max_tokens)
-            {
-                return Err(ConfigError::Invalid(format!(
-                    "{name} reasoning max_tokens ({cap}) must be > 0 and below \
-                     provider max_tokens ({}) to leave content room",
-                    self.provider.max_tokens,
-                )));
-            }
-        }
+        self.validate_model_overrides()?;
         self.validate_channels()?;
         if self.tools.exec.timeout_secs == 0 {
             return Err(ConfigError::Invalid("timeout_secs must be > 0".into()));
@@ -1063,6 +1033,43 @@ impl Config {
             }
             if p.gate.is_some() && !self.github.enabled {
                 return Err(ctx("gate \"new-commits\" requires github.enabled".into()));
+            }
+        }
+        Ok(())
+    }
+
+    /// Non-empty override specs, and reasoning bounds (root and
+    /// per-role) that fit the API and leave content room.
+    fn validate_model_overrides(&self) -> Result<(), ConfigError> {
+        for (role, spec) in self.provider.model_overrides.iter() {
+            if spec.model.is_none() && spec.reasoning.is_none() {
+                return Err(ConfigError::Invalid(format!(
+                    "model_overrides.{role} is empty: set model, reasoning, or both"
+                )));
+            }
+        }
+        let role_reasonings = self
+            .provider
+            .model_overrides
+            .iter()
+            .map(|(role, spec)| (role, spec.reasoning));
+        for (name, reasoning) in std::iter::once(("provider", self.provider.reasoning))
+            .chain(role_reasonings)
+            .filter_map(|(name, r)| r.map(|r| (name, r)))
+        {
+            if !matches!(self.provider.api, Api::OpenRouter) {
+                return Err(ConfigError::Invalid(format!(
+                    "{name} reasoning requires the openrouter api"
+                )));
+            }
+            if let Reasoning::MaxTokens(cap) = reasoning
+                && (cap == 0 || cap >= self.provider.max_tokens)
+            {
+                return Err(ConfigError::Invalid(format!(
+                    "{name} reasoning max_tokens ({cap}) must be > 0 and below \
+                     provider max_tokens ({}) to leave content room",
+                    self.provider.max_tokens,
+                )));
             }
         }
         Ok(())

--- a/src/duty/mod.rs
+++ b/src/duty/mod.rs
@@ -270,7 +270,7 @@ async fn checkout_note(duty: &Duty, git: Option<&GitCli>, repo: &str) -> String 
         return execution_checkout::CLONE_YOURSELF.into();
     };
     match execution_checkout::prepare(git, repo).await {
-        Ok(rel) => execution_checkout::ready_note(&rel),
+        Ok(prepared) => prepared.ready_note(),
         Err(e) => {
             warn!(duty = %duty.name, "duty checkout prep failed: {e}");
             execution_checkout::CLONE_YOURSELF.into()

--- a/src/tools/git/checkout.rs
+++ b/src/tools/git/checkout.rs
@@ -112,6 +112,19 @@ pub(crate) async fn run(
     Ok(())
 }
 
+/// Like [`run`], but returns the exit code and stdout for callers
+/// that branch on them; a non-zero exit is data here, not an error.
+/// Unauthenticated only — every probing caller is local.
+pub(crate) async fn run_read(
+    git: &GitCli,
+    args: &[&str],
+    cwd: &Path,
+) -> Result<(i32, String), ToolError> {
+    let call = git.prepare_git(args, cwd);
+    let out = git.exec_git(call, false).await?;
+    Ok((out.exit_code, out.stdout))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tools/git/git_cli.rs
+++ b/src/tools/git/git_cli.rs
@@ -286,8 +286,13 @@ const LONG_TIMEOUT_SECS: u64 = 900;
 /// so no call site has to remember. Everything else is bounded by
 /// local IO and keeps the default.
 fn hook_timeout(args: &[&str]) -> Option<u64> {
+    // The subcommand may sit behind leading `-c key=val` pairs.
+    let mut rest = args;
+    while let ["-c", _, tail @ ..] = rest {
+        rest = tail;
+    }
     matches!(
-        args.first(),
+        rest.first(),
         Some(&"clone" | &"commit" | &"fetch" | &"push")
     )
     .then_some(LONG_TIMEOUT_SECS)
@@ -457,6 +462,15 @@ mod tests {
             vec!["commit", "-m", "x"],
             vec!["fetch", "origin"],
             vec!["push", "origin", "b"],
+            vec![
+                "-c",
+                "user.name=k",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "x",
+            ],
         ] {
             assert_eq!(hook_timeout(&slow), Some(LONG_TIMEOUT_SECS), "{slow:?}");
         }


### PR DESCRIPTION
execution_checkout::prepare force-detaches at origin/HEAD and cleans before every execution turn, first and resumed alike. The fresh-base guarantee is sound, but "clean base" was implemented as "destroy whatever is present": a turn that died at the iteration cap lost its working tree to the next turn's prepare. Issue #47's implementation went that way and had to be redone from memory, and the bot's memory grew a pack-diffs-to-.diffs ritual that is not even a real recovery path, since exec children cannot read those files back (#83).

Preserve, then reset. On a reused checkout, prepare now parks leftovers on a kitaebot_recovered/<epoch> branch before the destructive steps: a dirty tree (tracked edits plus untracked files) is committed to the branch, and commits stranded on a detached HEAD get a name that survives the re-detach. The successor's ready note names the branch with inspect-and-salvage guidance. Clean checkouts and fresh clones park nothing, and the reset itself is unchanged, so a stale clone still cannot seed an outdated base.

The kept caches are excluded from the parked commit via pathspec, not just from the clean: committing node_modules or .gcroots to the park branch would make the tree-switch back to base delete them from the worktree, silently defeating the cache exclusions (and .gcroots loss would resurrect the issue-75 GC churn).

The park commit pins identity with -c and disables signing: it is a checkpoint, not authored work, and must not depend on the daemon's git config or keyring.

Config::validate moved its model-override checks into a helper; the merged #86 validation pushed the function over the clippy line limit.

The memory entries documenting the .diffs ritual (tooling.md and the MEMORY.md index line) are deleted after this deploys, per the issue's acceptance criteria — deleting them while the old binary still runs would re-expose turns to the destruction the ritual guards against.

Fixes #83