### PR TITLE
file_edit: hard-stop repeated futile payloads

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -327,6 +327,16 @@ normally. The window is a short per-path ring (not a consecutive
 counter), so alternating two failing payloads trips the guard for
 each.
 
+The history is one map shared across tasks and sub-agents — the tool
+is a daemon-lifetime singleton — so concurrent writers to the same
+path can race it: one agent's successful write clears counts another
+was accumulating, and interleaved attempts can trip the guard on a
+payload that would have succeeded after the next write. Both races
+are benign by the outcome-classifying design above: a cleared ring
+only delays the hard stop, and a spurious `EditLoop` costs exactly
+one re-read. The guard needs no serialization to stay correct, only
+to stay cheap — which a spurious trip does not threaten.
+
 ---
 
 ### `glob_search` — Find Files by Pattern

--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -254,7 +254,7 @@ complexity on making failures recoverable in the same turn.
 |-------|------|----------|-------|
 | `path` | String | yes | Relative to workspace |
 | `old_string` | String | yes | Must be non-empty |
-| `new_string` | String | yes | Replacement (empty = delete) |
+| `new_string` | String | yes | Replacement (empty = delete); must differ from `old_string` |
 | `replace_all` | Bool | no | Replace every exact match (default false) |
 
 **Match ladder** — four rungs tried in order; the first rung that

--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -309,6 +309,24 @@ same-turn re-issue of the edit against the excerpt, or a targeted
 `file_read` when the excerpt shows the file moved further than one
 window.
 
+**No-op loop guard**: the tool remembers recent futile payloads per
+path, in memory, for the daemon's lifetime. A payload is futile when
+it fails to match (or matches ambiguously), or when it matches but
+leaves the file byte-identical — reachable through a fuzzy rung even
+with `old_string != new_string`, when the replacement is the file's
+existing spelling. The third identical futile payload in a path's
+recent window returns `EditLoop` — a hard error instructing a re-read
+— instead of a third copy of the same result. Identical `old_string`
+and `new_string` never gets that far: it is rejected upfront as
+invalid arguments. A no-change success is labeled `(no change)` in the
+result and skips the write, so identical bytes never churn the mtime;
+a content-changing edit clears the path's history. The guard
+classifies outcomes rather than pre-blocking payloads: if the file
+changed since the failures and the same payload now lands, it succeeds
+normally. The window is a short per-path ring (not a consecutive
+counter), so alternating two failing payloads trips the guard for
+each.
+
 ---
 
 ### `glob_search` — Find Files by Pattern
@@ -662,6 +680,7 @@ period. Rooting stops at deps deliberately: check outputs
 | Command exited non-zero | `CommandFailed` | Error text (command, output, exit code) returned to LLM |
 | `file_edit` no match | `Precondition` | Error carries stale-read hint + bounded excerpt around the nearest candidate line (see tool section) |
 | `file_edit` ambiguous match | `Precondition` | Error lists rung, count, and match line numbers |
+| `file_edit` repeated futile payload | `EditLoop` | Third identical payload in a path's recent window that produced no change or failed identically; instructs a re-read |
 
 All errors are surfaced to the LLM as text. The LLM decides how to proceed.
 The agent loop's policy gate escalates repeated `Blocked` errors (see

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1808,16 +1808,16 @@ mod tests {
                 Some(FailureKind::Blocked),
             ),
             (
-                Err(ToolError::Precondition("exit 1".into())),
-                Some(FailureKind::Precondition),
-            ),
-            (
                 Err(ToolError::EditLoop {
                     path: "src/main.rs".into(),
                     attempts: 3,
                     outcome: crate::error::EditFutility::NoChange,
                 }),
                 Some(FailureKind::EditLoop),
+            ),
+            (
+                Err(ToolError::Precondition("exit 1".into())),
+                Some(FailureKind::Precondition),
             ),
             (
                 Err(ToolError::InvalidArguments("missing field".into())),

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1812,6 +1812,14 @@ mod tests {
                 Some(FailureKind::Precondition),
             ),
             (
+                Err(ToolError::EditLoop {
+                    path: "src/main.rs".into(),
+                    attempts: 3,
+                    outcome: crate::error::EditFutility::NoChange,
+                }),
+                Some(FailureKind::EditLoop),
+            ),
+            (
                 Err(ToolError::InvalidArguments("missing field".into())),
                 Some(FailureKind::InvalidArguments),
             ),

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -907,6 +907,7 @@ fn error_class(err: &ToolError) -> String {
         ToolError::Blocked { .. } => "blocked".into(),
         ToolError::Cancelled => "cancelled".into(),
         ToolError::CommandFailed { exit_code, .. } => format!("command_failed:{exit_code}"),
+        ToolError::EditLoop { .. } => "edit_loop".into(),
         ToolError::FtsQuery { .. } => "fts_query".into(),
         ToolError::Github(e) => match e {
             crate::error::GithubError::Api { status, .. } => format!("github:api:{status}"),

--- a/src/context/stats.rs
+++ b/src/context/stats.rs
@@ -33,6 +33,7 @@ pub(crate) enum FailureKind {
     /// `CommandFailed`'s rendering keeps the historical
     /// "Execution failed:" prefix, so old sessions classify the same.
     CommandFailed,
+    EditLoop,
     InvalidArguments,
     NotFound,
     Precondition,
@@ -53,6 +54,7 @@ impl fmt::Display for FailureKind {
         match self {
             Self::Blocked => write!(f, "Blocked"),
             Self::CommandFailed => write!(f, "CommandFailed"),
+            Self::EditLoop => write!(f, "EditLoop"),
             Self::InvalidArguments => write!(f, "InvalidArguments"),
             Self::NotFound => write!(f, "NotFound"),
             Self::Other => write!(f, "Other"),
@@ -219,6 +221,8 @@ pub(crate) fn classify_failure(content: &str) -> Option<FailureKind> {
         Some(FailureKind::Blocked)
     } else if content.starts_with("Error: Execution failed: ") {
         Some(FailureKind::CommandFailed)
+    } else if content.starts_with("Error: file_edit on ") {
+        Some(FailureKind::EditLoop)
     } else if content.starts_with("Error: precondition failed: ") {
         Some(FailureKind::Precondition)
     } else if content.starts_with("Error: Invalid arguments: ") {

--- a/src/error.rs
+++ b/src/error.rs
@@ -169,6 +169,24 @@ impl ProviderError {
 #[error("tool name {0:?} must match ^[a-zA-Z0-9_-]+$")]
 pub struct InvalidToolName(pub String);
 
+/// What every attempt in a [`ToolError::EditLoop`] produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditFutility {
+    /// Each attempt returned the same match failure.
+    FailedIdentically,
+    /// Each attempt matched but left the file byte-identical.
+    NoChange,
+}
+
+impl std::fmt::Display for EditFutility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FailedIdentically => f.write_str("failed identically"),
+            Self::NoChange => f.write_str("produced no change"),
+        }
+    }
+}
+
 /// Tool execution errors.
 #[derive(Debug, Error)]
 pub enum ToolError {
@@ -203,6 +221,23 @@ pub enum ToolError {
         exit_code: i32,
         /// `$ command`, stdout, stderr, `Exit code: N`.
         output: String,
+    },
+
+    /// The same `file_edit` payload was futile several times running:
+    /// the model is looping on a stale view of the file. No `#[source]`
+    /// carrying the repeated result — the model already received it
+    /// verbatim twice; the payload here is the instruction to stop.
+    #[error(
+        "file_edit on {path} {outcome} {attempts} times running; \
+         re-read the file to re-anchor before editing it again"
+    )]
+    EditLoop {
+        /// The workspace-relative path the edits targeted.
+        path: String,
+        /// Occurrences of this payload in the path's recent window.
+        attempts: usize,
+        /// What every attempt produced.
+        outcome: EditFutility,
     },
 
     /// FTS5 rejected an `lcm_grep` search pattern as query syntax and
@@ -429,6 +464,7 @@ impl ToolError {
             // what the service returns, so they log whole.
             Self::Blocked { .. }
             | Self::Cancelled
+            | Self::EditLoop { .. }
             | Self::FtsQuery { .. }
             | Self::Github(_)
             | Self::Http { .. }

--- a/src/tools/file_edit.rs
+++ b/src/tools/file_edit.rs
@@ -6,9 +6,11 @@
 //! first rung with at least one match decides the outcome.
 
 use std::cmp::Reverse;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::future::Future;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::pin::Pin;
+use std::sync::Mutex;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -16,7 +18,7 @@ use tracing::debug;
 
 use super::path::PathGuard;
 use super::{Tool, ToolCtx, truncate_output};
-use crate::error::ToolError;
+use crate::error::{EditFutility, ToolError};
 
 #[derive(Deserialize, JsonSchema)]
 struct Args {
@@ -37,11 +39,38 @@ struct Args {
 /// Tool that performs find-and-replace edits on workspace files.
 pub struct FileEdit {
     guard: PathGuard,
+    history: Mutex<EditHistory>,
 }
 
 impl FileEdit {
     pub fn new(guard: PathGuard) -> Self {
-        Self { guard }
+        Self {
+            guard,
+            history: Mutex::new(EditHistory::default()),
+        }
+    }
+
+    /// Record a futile attempt; the third identical payload in the
+    /// path's recent window becomes a hard stop.
+    fn record_futile(
+        &self,
+        path: &str,
+        fingerprint: u64,
+        outcome: EditFutility,
+    ) -> Result<(), ToolError> {
+        let attempts = self
+            .history
+            .lock()
+            .expect("edit history mutex poisoned")
+            .record_futile(path, fingerprint);
+        if attempts >= FUTILE_LIMIT {
+            return Err(ToolError::EditLoop {
+                path: path.to_string(),
+                attempts,
+                outcome,
+            });
+        }
+        Ok(())
     }
 }
 
@@ -89,7 +118,9 @@ impl Tool for FileEdit {
                 source: e,
             })?;
 
+            let fingerprint = fingerprint(&args);
             let Some((rung, spans)) = find_matches(&content, &args.old_string) else {
+                self.record_futile(&args.path, fingerprint, EditFutility::FailedIdentically)?;
                 return Err(ToolError::Precondition(stale_read_message(
                     &content,
                     &args.old_string,
@@ -109,12 +140,23 @@ impl Tool for FileEdit {
                     many.len(),
                 ),
                 many => {
+                    self.record_futile(&args.path, fingerprint, EditFutility::FailedIdentically)?;
                     return Err(ToolError::Precondition(ambiguous_message(
                         rung, many, &content, &args.path,
                     )));
                 }
             };
 
+            if result == content {
+                self.record_futile(&args.path, fingerprint, EditFutility::NoChange)?;
+                let echo = echo_region(&result, edited_at, args.new_string.len());
+                return Ok(format!("Edited {} (no change):\n{echo}", args.path));
+            }
+
+            self.history
+                .lock()
+                .expect("edit history mutex poisoned")
+                .clear(&args.path);
             std::fs::write(&resolved, &result).map_err(|e| ToolError::Io {
                 operation: "write",
                 path: (&args.path).into(),
@@ -132,6 +174,53 @@ impl Tool for FileEdit {
             }
         })
     }
+}
+
+/// Attempts of one identical futile payload that trip the guard.
+const FUTILE_LIMIT: usize = 3;
+
+/// Futile payloads remembered per path.
+const RECENT_WINDOW: usize = 8;
+
+/// Paths tracked before the history resets. A heuristic guard, not a
+/// ledger: losing counts on overflow only delays a hard stop.
+const MAX_PATHS: usize = 32;
+
+/// Recent futile edit payloads per path — attempts that failed to
+/// match or matched without changing the file. A ring rather than a
+/// consecutive counter, so interleaving two failing payloads still
+/// trips the guard for each.
+#[derive(Default)]
+struct EditHistory(HashMap<String, VecDeque<u64>>);
+
+impl EditHistory {
+    /// Record a futile attempt; returns how many times this
+    /// fingerprint appears in the path's recent window, this one
+    /// included.
+    fn record_futile(&mut self, path: &str, fingerprint: u64) -> usize {
+        if self.0.len() >= MAX_PATHS && !self.0.contains_key(path) {
+            self.0.clear();
+        }
+        let ring = self.0.entry(path.to_string()).or_default();
+        if ring.len() >= RECENT_WINDOW {
+            ring.pop_front();
+        }
+        ring.push_back(fingerprint);
+        ring.iter().filter(|&&f| f == fingerprint).count()
+    }
+
+    /// A content-changing edit landed; prior futility is stale.
+    fn clear(&mut self, path: &str) {
+        self.0.remove(path);
+    }
+}
+
+/// Collision-tolerant payload identity: a false positive fires the
+/// guard early with a re-read instruction, which is harmless.
+fn fingerprint(args: &Args) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    (&args.old_string, &args.new_string, args.replace_all).hash(&mut hasher);
+    hasher.finish()
 }
 
 /// A matched byte range in the original content.
@@ -684,6 +773,141 @@ mod tests {
         let (_dir, tool) = setup("content");
         let result = edit(&tool, "", "x").await;
         assert!(matches!(result, Err(ToolError::InvalidArguments(_))));
+    }
+
+    async fn edit_path(
+        tool: &FileEdit,
+        path: &str,
+        old_string: &str,
+        new_string: &str,
+    ) -> Result<String, ToolError> {
+        tool.execute(
+            serde_json::json!({
+                "path": path,
+                "old_string": old_string,
+                "new_string": new_string
+            }),
+            ToolCtx::default(),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn third_identical_no_match_hard_stops() {
+        let (_dir, tool) = setup("hello world");
+        for _ in 0..2 {
+            let result = edit(&tool, "missing", "x").await;
+            assert!(
+                matches!(result, Err(ToolError::Precondition(_))),
+                "{result:?}"
+            );
+        }
+        let result = edit(&tool, "missing", "x").await;
+        match result {
+            Err(ToolError::EditLoop {
+                attempts: 3,
+                outcome: EditFutility::FailedIdentically,
+                ref path,
+            }) => assert_eq!(path, "test.txt"),
+            other => panic!("expected EditLoop, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn third_identical_no_change_hard_stops() {
+        // Whitespace-flexible match where the replacement equals the
+        // file's existing bytes: a no-change success.
+        let (dir, tool) = setup("foo( 1 );\n");
+        for _ in 0..2 {
+            let result = edit(&tool, "foo(  1 );", "foo( 1 );").await.unwrap();
+            assert!(result.contains("(no change)"), "{result}");
+        }
+        let result = edit(&tool, "foo(  1 );", "foo( 1 );").await;
+        assert!(
+            matches!(
+                result,
+                Err(ToolError::EditLoop {
+                    attempts: 3,
+                    outcome: EditFutility::NoChange,
+                    ..
+                })
+            ),
+            "{result:?}"
+        );
+        assert_eq!(read(&dir), "foo( 1 );\n");
+    }
+
+    #[tokio::test]
+    async fn changing_edit_clears_futility() {
+        let (_dir, tool) = setup("hello world");
+        for _ in 0..2 {
+            edit(&tool, "missing", "x").await.unwrap_err();
+        }
+        edit(&tool, "hello", "goodbye").await.unwrap();
+        // The counter restarted: the same payload gets two more
+        // ordinary errors before the guard would trip again.
+        for _ in 0..2 {
+            let result = edit(&tool, "missing", "x").await;
+            assert!(
+                matches!(result, Err(ToolError::Precondition(_))),
+                "{result:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn interleaved_failing_payloads_each_trip() {
+        let (_dir, tool) = setup("hello world");
+        for _ in 0..2 {
+            edit(&tool, "missing a", "x").await.unwrap_err();
+            edit(&tool, "missing b", "x").await.unwrap_err();
+        }
+        let result = edit(&tool, "missing a", "x").await;
+        assert!(
+            matches!(result, Err(ToolError::EditLoop { .. })),
+            "{result:?}"
+        );
+        let result = edit(&tool, "missing b", "x").await;
+        assert!(
+            matches!(result, Err(ToolError::EditLoop { .. })),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn paths_do_not_share_futility() {
+        let (dir, tool) = setup("hello world");
+        std::fs::write(dir.path().join("other.txt"), "hello world").unwrap();
+        for _ in 0..2 {
+            edit(&tool, "missing", "x").await.unwrap_err();
+        }
+        let result = edit_path(&tool, "other.txt", "missing", "x").await;
+        assert!(
+            matches!(result, Err(ToolError::Precondition(_))),
+            "{result:?}"
+        );
+    }
+
+    #[test]
+    fn history_window_evicts_old_fingerprints() {
+        let mut history = EditHistory::default();
+        assert_eq!(history.record_futile("p", 0), 1);
+        for f in 1..=RECENT_WINDOW as u64 {
+            history.record_futile("p", f);
+        }
+        // Fingerprint 0 was pushed out of the window.
+        assert_eq!(history.record_futile("p", 0), 1);
+    }
+
+    #[test]
+    fn history_path_cap_resets() {
+        let mut history = EditHistory::default();
+        for p in 0..MAX_PATHS {
+            history.record_futile(&format!("p{p}"), 7);
+        }
+        // The overflowing path wipes the map; counts restart at one.
+        assert_eq!(history.record_futile("overflow", 7), 1);
+        assert_eq!(history.record_futile("p0", 7), 1);
     }
 
     #[test]

--- a/src/tools/file_edit.rs
+++ b/src/tools/file_edit.rs
@@ -25,7 +25,8 @@ struct Args {
     /// The exact string to find. Must match exactly once, unless
     /// `replace_all` is set.
     old_string: String,
-    /// The replacement string. Empty string deletes the match.
+    /// The replacement string. Empty string deletes the match. Must
+    /// differ from `old_string`.
     new_string: String,
     /// Replace every exact occurrence of `old_string`. Only applies to
     /// exact matches; fuzzy matches always require a unique target.
@@ -72,6 +73,11 @@ impl Tool for FileEdit {
             if args.old_string.is_empty() {
                 return Err(ToolError::InvalidArguments(
                     "old_string must be non-empty".into(),
+                ));
+            }
+            if args.old_string == args.new_string {
+                return Err(ToolError::InvalidArguments(
+                    "old_string and new_string are identical; the edit would be a no-op".into(),
                 ));
             }
 
@@ -663,6 +669,14 @@ mod tests {
             }
             other => panic!("expected Precondition, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn identical_old_and_new_rejected() {
+        let (dir, tool) = setup("content");
+        let result = edit(&tool, "content", "content").await;
+        assert!(matches!(result, Err(ToolError::InvalidArguments(_))));
+        assert_eq!(read(&dir), "content");
     }
 
     #[tokio::test]

--- a/src/tools/file_edit.rs
+++ b/src/tools/file_edit.rs
@@ -920,7 +920,9 @@ mod tests {
         assert_eq!(history.record_futile("overflow", 7), 1);
         // p0 was evicted and restarts; p1 kept its count.
         assert_eq!(history.record_futile("p1", 7), 2);
+        // Re-tracking p0 at capacity evicts the next-oldest path, p1.
         assert_eq!(history.record_futile("p0", 7), 1);
+        assert_eq!(history.record_futile("p1", 7), 1);
     }
 
     #[test]

--- a/src/tools/file_edit.rs
+++ b/src/tools/file_edit.rs
@@ -182,8 +182,8 @@ const FUTILE_LIMIT: usize = 3;
 /// Futile payloads remembered per path.
 const RECENT_WINDOW: usize = 8;
 
-/// Paths tracked before the history resets. A heuristic guard, not a
-/// ledger: losing counts on overflow only delays a hard stop.
+/// Paths tracked before the oldest is evicted. Eviction is per-path,
+/// so an overflow never disarms another path's near-trip count.
 const MAX_PATHS: usize = 32;
 
 /// Recent futile edit payloads per path — attempts that failed to
@@ -191,17 +191,27 @@ const MAX_PATHS: usize = 32;
 /// consecutive counter, so interleaving two failing payloads still
 /// trips the guard for each.
 #[derive(Default)]
-struct EditHistory(HashMap<String, VecDeque<u64>>);
+struct EditHistory {
+    by_path: HashMap<String, VecDeque<u64>>,
+    /// First-record order of tracked paths; the front is evicted on
+    /// overflow.
+    order: VecDeque<String>,
+}
 
 impl EditHistory {
-    /// Record a futile attempt; returns how many times this
-    /// fingerprint appears in the path's recent window, this one
-    /// included.
+    /// Record a futile attempt; returns this fingerprint's total
+    /// occurrences anywhere in the path's recent window (not a
+    /// consecutive run), this one included.
     fn record_futile(&mut self, path: &str, fingerprint: u64) -> usize {
-        if self.0.len() >= MAX_PATHS && !self.0.contains_key(path) {
-            self.0.clear();
+        if !self.by_path.contains_key(path) {
+            if self.by_path.len() >= MAX_PATHS
+                && let Some(oldest) = self.order.pop_front()
+            {
+                self.by_path.remove(&oldest);
+            }
+            self.order.push_back(path.to_string());
         }
-        let ring = self.0.entry(path.to_string()).or_default();
+        let ring = self.by_path.entry(path.to_string()).or_default();
         if ring.len() >= RECENT_WINDOW {
             ring.pop_front();
         }
@@ -211,7 +221,9 @@ impl EditHistory {
 
     /// A content-changing edit landed; prior futility is stale.
     fn clear(&mut self, path: &str) {
-        self.0.remove(path);
+        if self.by_path.remove(path).is_some() {
+            self.order.retain(|p| p != path);
+        }
     }
 }
 
@@ -900,14 +912,27 @@ mod tests {
     }
 
     #[test]
-    fn history_path_cap_resets() {
+    fn history_path_cap_evicts_only_the_oldest_path() {
         let mut history = EditHistory::default();
         for p in 0..MAX_PATHS {
             history.record_futile(&format!("p{p}"), 7);
         }
-        // The overflowing path wipes the map; counts restart at one.
         assert_eq!(history.record_futile("overflow", 7), 1);
+        // p0 was evicted and restarts; p1 kept its count.
+        assert_eq!(history.record_futile("p1", 7), 2);
         assert_eq!(history.record_futile("p0", 7), 1);
+    }
+
+    #[test]
+    fn history_clear_untracks_the_path() {
+        let mut history = EditHistory::default();
+        history.record_futile("p", 7);
+        history.clear("p");
+        assert!(history.order.is_empty());
+        // Re-recording tracks the path exactly once.
+        history.record_futile("p", 7);
+        history.record_futile("p", 7);
+        assert_eq!(history.order.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Closes #102.

The issue's first half (post-edit preview) already landed in b70a861: every success echoes the edited region with line numbers and three lines of context, and spec 03 documents it under "Success result". This PR implements the remaining half, the no-op loop guard, plus one upfront rejection the guard made obvious.

**Reject `old_string == new_string`.** A payload with identical old and new strings is a no-op by definition, but the tool accepted it, rewrote the file with the same bytes, and returned a normal success echo. It now fails upfront as `InvalidArguments`.

**Hard-stop repeated futile payloads.** The tool remembers recent futile payloads per path as u64 fingerprints in a short ring. A payload is futile when it fails to match (or matches ambiguously) or when it matches but leaves the file byte-identical, which a fuzzy rung can do even with differing strings. The third identical payload in the window returns `EditLoop`, a new `ToolError` variant instructing a re-read, instead of a third copy of the same result. No-change successes are labeled `(no change)` and skip the write; a content-changing edit clears the path's history. The guard classifies outcomes and never pre-blocks: if the file changed since the failures and the same payload now lands, it just succeeds.

Spec 03 gains a "No-op loop guard" section and an error-mode table row. `error_class` in the agent loop groups the new variant as `edit_loop` for strike escalation.
