### PR TITLE
Render the session name desanitized on every display surface

### DIFF
--- a/src/agent/actor.rs
+++ b/src/agent/actor.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use tracing::{Instrument, error, field, info_span};
 
 use crate::commands;
+use crate::context::names::display_name;
 use crate::context::{ContextEngine, SummarizeFn};
 use crate::dispatch::{Input, Reply};
 use crate::duty::TriggerHandle;
@@ -134,7 +135,7 @@ impl<P: Provider + 'static, E: ContextEngine + 'static> Agent<P, E> {
 
     /// Greeting derived from current engine state.
     fn format_greeting(&self) -> String {
-        let active = self.engine.active_session();
+        let active = display_name(self.engine.active_session());
         let count = self.engine.stats().message_count;
         if count == 0 {
             format!("New session: {active}")
@@ -261,7 +262,10 @@ impl<P: Provider + 'static, E: ContextEngine + 'static> Agent<P, E> {
         let original = self.engine.active_session().to_string();
         let target = envelope.session_hint.as_deref().unwrap_or(&original);
         let switched = target != original;
-        tracing::Span::current().record("session", target);
+        // Display rendering (spec 14): the span shows `owner/repo`,
+        // the same form every other operator-facing surface shows,
+        // never the sanitized storage name.
+        tracing::Span::current().record("session", display_name(target));
 
         if switched {
             // switch_session saves the current session before loading the target.
@@ -552,6 +556,111 @@ mod tests {
         assert!(!general.contains("github msg"));
         assert!(github.contains("github msg"));
         assert!(!github.contains("socket msg"));
+    }
+
+    /// The turn span's `session` field is display rendering (spec 14):
+    /// `owner/repo`, never the sanitized storage name — the same
+    /// conversation must not render under two names in the log. The
+    /// leak case is a no-hint turn (the span records the *active*
+    /// session, stored sanitized), so the test first makes a
+    /// repo-style session active via `/project`.
+    #[tokio::test]
+    async fn turn_span_shows_desanitized_session() {
+        use tracing_subscriber::Layer;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        /// Captures values recorded onto span fields named `session`.
+        struct Capture(Arc<std::sync::Mutex<Vec<String>>>);
+        impl<S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer<S>
+            for Capture
+        {
+            fn on_record(
+                &self,
+                _id: &tracing::span::Id,
+                values: &tracing::span::Record<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                let mut visit = SessionField(None);
+                values.record(&mut visit);
+                if let Some(s) = visit.0 {
+                    self.0.lock().unwrap().push(s);
+                }
+            }
+        }
+        struct SessionField(Option<String>);
+        impl tracing::field::Visit for SessionField {
+            fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                if field.name() == "session" {
+                    self.0 = Some(value.to_string());
+                }
+            }
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "session" {
+                    self.0 = Some(format!("{value:?}"));
+                }
+            }
+        }
+
+        let (_dir, ws) = workspace();
+        let provider = Arc::new(MockProvider::new(vec![
+            Ok(Response::Text("first".into())),
+            Ok(Response::Text("second".into())),
+        ]));
+        let handle = spawn_agent(ws, provider);
+
+        let recorded = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = recorded.clone();
+        let subscriber = tracing_subscriber::registry().with(Capture(captured));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        // Create the repo-style session (GitHub turns route by hint).
+        handle
+            .send_message(
+                ChannelSource::GitHub {
+                    pr_number: 1,
+                    repo: "owner/repo".into(),
+                    role: GitHubRole::Author,
+                },
+                "github msg".into(),
+                Some("owner/repo".into()),
+                None,
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        // Make it the persisted active session.
+        handle
+            .send_message(
+                ChannelSource::Socket,
+                "/project owner/repo".into(),
+                None,
+                None,
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        // The leak case: no hint, so the span records the active
+        // session — stored sanitized, displayed desanitized.
+        handle
+            .send_message(
+                ChannelSource::Socket,
+                "socket msg".into(),
+                None,
+                None,
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let sessions = recorded.lock().unwrap().clone();
+        assert!(
+            !sessions.is_empty(),
+            "no session field was recorded onto a turn span"
+        );
+        assert!(
+            sessions.iter().all(|s| s == "owner/repo"),
+            "sanitized session name leaked into a turn span: {sessions:?}"
+        );
     }
 
     /// Notifier over a fake Telegram client that records sendMessage bodies.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 
 use tracing::error;
 
-use crate::context::names::sanitize_name;
+use crate::context::names::{display_name, sanitize_name};
 use crate::context::{ContextEngine, SessionInfo, SummarizeFn};
 use crate::dispatch::Reply;
 use crate::memory::distill::{self, Distiller};
@@ -233,7 +233,7 @@ fn context_reply(engine: &impl ContextEngine) -> Reply {
         stats.token_estimate,
         stats.budget,
         stats.message_count,
-        engine.active_session(),
+        display_name(engine.active_session()),
     ))
 }
 
@@ -384,7 +384,7 @@ async fn switch_project(engine: &mut impl ContextEngine, name: &str) -> Result<R
     }
     Ok(Reply::text(format!(
         "Switched to '{}' ({} messages)",
-        engine.active_session(),
+        display_name(engine.active_session()),
         engine.stats().message_count,
     )))
 }
@@ -435,7 +435,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(engine.active_session(), "CumuloGlobal--open-money");
-        assert!(reply.content.contains("Switched to"), "{}", reply.content);
+        assert!(
+            reply
+                .content
+                .contains("Switched to 'CumuloGlobal/open-money'"),
+            "{}",
+            reply.content
+        );
     }
 
     #[tokio::test]

--- a/src/context/names.rs
+++ b/src/context/names.rs
@@ -15,6 +15,14 @@ pub(crate) fn desanitize_name(stem: &str) -> String {
     stem.replace("--", "/")
 }
 
+/// The single display rendering of a stored (sanitized) session name
+/// (spec 14): every operator-facing surface shows `owner/repo`, never
+/// the storage form `owner--repo`. Ambiguous on names that genuinely
+/// contain `--`, but storage never desanitizes, so it is display-only.
+pub(crate) fn display_name(session: &str) -> String {
+    desanitize_name(session)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -49,5 +57,11 @@ mod tests {
     #[test]
     fn sanitize_plain_name_unchanged() {
         assert_eq!(sanitize_name("general"), "general");
+    }
+
+    #[test]
+    fn display_name_desanitizes_storage_form() {
+        assert_eq!(display_name("owner--repo"), "owner/repo");
+        assert_eq!(display_name("general"), "general");
     }
 }


### PR DESCRIPTION
Closes #98

## Problem

The turn span's `session` field rendered the same conversation under two names: the raw envelope hint for GitHub-channel turns (`session="amackillop/kitaebot"`) but the stored sanitized name for socket turns (`session="amackillop--kitaebot"`). The `/project` switch confirmation also printed the sanitized form, though spec 14 says display output desanitizes. Filtering the journal by one spelling silently missed the turns recorded under the other.

## Fix

One shared helper, `display_name` in `src/context/names.rs` (a direct `desanitize_name` call), now feeds every operator-facing rendering of the active session name:

- the turn span (`handle_message` records `display_name(target)` onto the span)
- the socket greeting
- the `/project` switch confirmation
- the `/context` Session line

Storage is untouched: engine internals, the usage ledger's `session` column, and the conventions lookup keep the sanitized form, so no stored data changes spelling across this commit. Spec 14 already stated the contract; the code was the divergence, so no spec change was needed.

## Tests

- `display_name_desanitizes_storage_form` (unit)
- `turn_span_shows_desanitized_session` — a tracing-subscriber layer captures values recorded onto the turn span's `session` field (via `on_record`, the hook `Span::record` fires); drives the leak case (no-hint socket turn with a repo-style active session) and asserts the capture is non-empty and every value is `owner/repo`
- `switch_project_accepts_existing_repo_style_name` tightened: the reply shows `Switched to 'CumuloGlobal/open-money'` while the engine's active session stays `CumuloGlobal--open-money`

`just check` (nix flake check: clippy, fmt, tests) passes. The 32 git-fixture failures seen in `just rust-check` are the known pre-existing sandbox class (GPG signing in exec), confirmed on clean master.

## Notes

- The `foo--bar` ambiguity is display-only (a repo genuinely named `foo--bar` displays as `foo/bar`), the same ambiguity `desanitize_name` already has; storage never desanitizes.
- Commit-gate and series-gate reviews ran; the series verdict was correct with one nit (a redundant `contains("--")` guard, removed).