### PR TITLE
Record and report prompt-cache hits in /usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ kitaebot = {
     sub_agents = {
       max_iterations = 30;                       # Tool-loop cap per sub-agent turn
     };
+    usage = {
+      rates = {                                  # USD per 1M tokens, for /usage cache savings (spec 27)
+        "z-ai/glm-5.2" = {
+          input_per_mtok = 0.4046;               # Rates vary by upstream endpoint; use your provider's
+          cache_read_per_mtok = 0.07514;
+        };
+      };
+    };
     context = {
       engine = "flat";                           # flat | lcm
       max_tokens = 200000;

--- a/specs/27-usage.md
+++ b/specs/27-usage.md
@@ -136,6 +136,17 @@ dilute the rate toward zero, and a group with no measurable rows
 shows `-`, consistent with the never-render-absence-as-zero rule.
 The header omits the rate entirely on an all-legacy ledger.
 
+Below the header, a `Cache savings` line estimates the USD saved by
+cache hits: cached tokens billed at the cache-read rate instead of
+the input rate, priced from operator-supplied `[usage.rates]` config
+(USD per million tokens per model id; rates vary by upstream
+endpoint, so they are never built in). The estimate is signed — a
+policy whose cache costs exceed its savings must report a negative
+number. Rows whose model has no configured rate are counted as
+`(N turns unpriced)` rather than skipped: silence would hide a
+misconfigured map. The line is absent when no rates are configured
+or no row has cache data.
+
 ## Boundaries
 
 ### Owns

--- a/specs/27-usage.md
+++ b/specs/27-usage.md
@@ -127,8 +127,14 @@ mixing eras shows cost from all rows and timing from the timed ones;
 `-` marks absent data, never rendered as zero.
 
 `By Build` ($/turn per deploy — the cost-regression view) and
-`By Model` follow unchanged. Tokens stay in those tables; the task
-table is cost and time.
+`By Model` follow. Tokens stay in those tables; the task table is
+cost and time. Both carry a `Cache` column — the share of prompt
+tokens served from the provider's cache — and the report header the
+overall rate. The rate's denominator is the prompt tokens of only
+the rows that recorded `cached_tokens`: pre-0004 history must not
+dilute the rate toward zero, and a group with no measurable rows
+shows `-`, consistent with the never-render-absence-as-zero rule.
+The header omits the rate entirely on an all-legacy ledger.
 
 ## Boundaries
 

--- a/specs/27-usage.md
+++ b/specs/27-usage.md
@@ -30,7 +30,7 @@ wording change would silently split ledger history.
 ### Schema
 
 The `turns` table in `state/kitaebot.db` (spec 05), migrations
-`0001_baseline.sql` through `0003_turn_timing.sql`:
+`0001_baseline.sql` through `0004_cached_tokens.sql`:
 
 | Column | Added | Meaning |
 |--------|-------|---------|
@@ -47,6 +47,7 @@ The `turns` table in `state/kitaebot.db` (spec 05), migrations
 | `started_at` | 0003 | Turn start, epoch seconds; NULL on legacy rows |
 | `duration_ms` | 0003 | Wall time of the turn; NULL on legacy rows |
 | `outcome` | 0003 | Turn outcome label; NULL on legacy rows |
+| `cached_tokens` | 0004 | Prompt-cache hits, subset of `prompt_tokens`, summed over the calls that reported `prompt_tokens_details`; NULL when none did or on legacy rows |
 
 All post-baseline columns are nullable so both eras of rows parse.
 No index on `task`: the report reads the whole ledger by design and

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -278,6 +278,9 @@ pub(crate) struct TurnUsage {
     pub calls: u32,
     /// Prompt tokens billed, summed across calls.
     pub prompt_tokens: u64,
+    /// Prompt-cache hits, summed across the calls that reported them;
+    /// `None` when no call did (same contract as `cost`).
+    pub cached_tokens: Option<u64>,
     /// Tokens generated, summed across calls.
     pub completion_tokens: u64,
     /// Charged cost in USD, summed across calls; `None` when no call
@@ -290,6 +293,9 @@ impl TurnUsage {
         self.calls += 1;
         if let Some(prompt) = call.prompt_tokens {
             self.prompt_tokens += u64::from(prompt);
+        }
+        if let Some(cached) = call.cached_tokens {
+            self.cached_tokens = Some(self.cached_tokens.unwrap_or(0) + u64::from(cached));
         }
         self.completion_tokens += u64::from(call.completion_tokens);
         if let Some(cost) = call.cost {
@@ -1099,6 +1105,7 @@ mod tests {
         let mut usage = TurnUsage::default();
         usage.add_call(CallUsage {
             prompt_tokens: Some(100),
+            cached_tokens: Some(80),
             completion_tokens: 20,
             cost: Some(0.001),
         });
@@ -1106,11 +1113,13 @@ mod tests {
         usage.add_call(CallUsage::default());
         usage.add_call(CallUsage {
             prompt_tokens: Some(50),
+            cached_tokens: Some(0),
             completion_tokens: 10,
             cost: Some(0.002),
         });
         assert_eq!(usage.calls, 3);
         assert_eq!(usage.prompt_tokens, 150);
+        assert_eq!(usage.cached_tokens, Some(80));
         assert_eq!(usage.completion_tokens, 30);
         assert_eq!(usage.cost, Some(0.003));
     }
@@ -1120,11 +1129,14 @@ mod tests {
         let mut usage = TurnUsage::default();
         usage.add_call(CallUsage {
             prompt_tokens: Some(10),
+            cached_tokens: None,
             completion_tokens: 5,
             cost: None,
         });
         assert_eq!(usage.calls, 1);
         assert_eq!(usage.cost, None);
+        // No call reported cache details: absent, not zero.
+        assert_eq!(usage.cached_tokens, None);
     }
 
     fn text(s: &str) -> Response {

--- a/src/agent/task.rs
+++ b/src/agent/task.rs
@@ -501,7 +501,7 @@ mod tests {
     async fn child_row_inherits_the_parent_task() {
         let dir = tempfile::tempdir().unwrap();
         let db = crate::state_db::StateDb::open(&dir.path().join("kitaebot.db")).unwrap();
-        let ledger = Arc::new(UsageLedger::new(&db));
+        let ledger = Arc::new(UsageLedger::new(&db, std::collections::HashMap::new()));
         let provider = Arc::new(MockProvider::new(vec![Ok(Response::Text("done".into()))]));
         let tool = TaskTool::new(
             same_provider(&provider),
@@ -552,7 +552,7 @@ mod tests {
     async fn child_row_without_task_records_null() {
         let dir = tempfile::tempdir().unwrap();
         let db = crate::state_db::StateDb::open(&dir.path().join("kitaebot.db")).unwrap();
-        let ledger = Arc::new(UsageLedger::new(&db));
+        let ledger = Arc::new(UsageLedger::new(&db, std::collections::HashMap::new()));
         let provider = Arc::new(MockProvider::new(vec![Ok(Response::Text("done".into()))]));
         let tool = TaskTool::new(
             same_provider(&provider),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -175,7 +175,7 @@ pub async fn execute(
             None => Ok(Reply::text("Usage tracking is disabled.".into())),
             Some(ledger) => ledger
                 .rows()
-                .map(|rows| Reply::pre(usage::report(&rows)))
+                .map(|rows| Reply::pre(usage::report(&rows, ledger.rates())))
                 .map_err(|e| format!("Usage query failed: {e}")),
         },
         SlashCommand::Findings => match review_ledger {

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,26 @@ pub struct Config {
     pub telegram: TelegramConfig,
     #[serde(default)]
     pub tools: ToolsConfig,
+    #[serde(default)]
+    pub usage: UsageConfig,
+}
+
+/// Usage-report settings (spec 27).
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct UsageConfig {
+    /// Prices per model, keyed by the provider model id, for the
+    /// report's cache-savings estimate. Empty means no estimate.
+    pub rates: std::collections::HashMap<String, ModelRates>,
+}
+
+/// One model's input prices, in USD per million tokens. Rates vary by
+/// upstream endpoint, so these are operator-supplied, not built in.
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ModelRates {
+    pub input_per_mtok: f64,
+    pub cache_read_per_mtok: f64,
 }
 
 /// Agent loop settings.

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,7 +390,10 @@ fn spawn_with_engine<E: ContextEngine + 'static>(
     // Telemetry: an open failure is logged and the daemon runs
     // unmetered and unrecorded. Opened before the task tool so
     // sub-agent turns share the ledgers.
-    let usage_ledger = Some(Arc::new(usage::UsageLedger::new(state_db)));
+    let usage_ledger = Some(Arc::new(usage::UsageLedger::new(
+        state_db,
+        config.usage.rates.clone(),
+    )));
     let review_ledger = config
         .review
         .enabled

--- a/src/provider/completions.rs
+++ b/src/provider/completions.rs
@@ -158,6 +158,7 @@ impl CompletionsProvider {
             .as_ref()
             .map_or_else(CallUsage::default, |u| CallUsage {
                 prompt_tokens: Some(u.prompt_tokens),
+                cached_tokens: u.prompt_tokens_details.as_ref().map(|d| d.cached_tokens),
                 completion_tokens: u.completion_tokens,
                 cost: u.cost,
             });
@@ -453,7 +454,8 @@ mod tests {
                 status: 200,
                 body: br#"{
                     "choices":[{"message":{"content":"hi"}}],
-                    "usage":{"prompt_tokens":42,"completion_tokens":7,"cost":0.0013}
+                    "usage":{"prompt_tokens":42,"completion_tokens":7,"cost":0.0013,
+                             "prompt_tokens_details":{"cached_tokens":30}}
                 }"#
                 .to_vec(),
             })
@@ -461,8 +463,28 @@ mod tests {
         let provider = CompletionsProvider::new(client, &ProviderConfig::default());
         let outcome = provider.chat("s", &[], &[]).await.unwrap();
         assert_eq!(outcome.usage.prompt_tokens, Some(42));
+        assert_eq!(outcome.usage.cached_tokens, Some(30));
         assert_eq!(outcome.usage.completion_tokens, 7);
         assert_eq!(outcome.usage.cost, Some(0.0013));
+    }
+
+    /// Usage without `prompt_tokens_details` must surface cache hits
+    /// as absent, not zero — "can't know" and "cold prompt" differ.
+    #[tokio::test]
+    async fn chat_without_cache_details_leaves_cached_none() {
+        let client = CompletionsClient::from_fn(|_body| async {
+            Ok(crate::clients::RawResponse {
+                status: 200,
+                body: br#"{
+                    "choices":[{"message":{"content":"hi"}}],
+                    "usage":{"prompt_tokens":42,"completion_tokens":7}
+                }"#
+                .to_vec(),
+            })
+        });
+        let provider = CompletionsProvider::new(client, &ProviderConfig::default());
+        let outcome = provider.chat("s", &[], &[]).await.unwrap();
+        assert_eq!(outcome.usage.cached_tokens, None);
     }
 
     #[tokio::test]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -33,6 +33,10 @@ pub struct CallUsage {
     /// reports usage. Ground truth for context size — includes system
     /// prompt and tool schemas that char-based estimates miss.
     pub prompt_tokens: Option<u32>,
+    /// Subset of `prompt_tokens` served from the provider's prompt
+    /// cache. `None` when the response carried no
+    /// `prompt_tokens_details`; `Some(0)` is a reported cold prompt.
+    pub cached_tokens: Option<u32>,
     /// Tokens generated in the reply.
     pub completion_tokens: u32,
     /// Charged cost in USD; `OpenRouter` only, `None` elsewhere.

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -34,6 +34,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("state_db/migrations/0001_baseline.sql"),
     include_str!("state_db/migrations/0002_task.sql"),
     include_str!("state_db/migrations/0003_turn_timing.sql"),
+    include_str!("state_db/migrations/0004_cached_tokens.sql"),
 ];
 
 /// Shared handle to the operational state database.

--- a/src/state_db/migrations/0004_cached_tokens.sql
+++ b/src/state_db/migrations/0004_cached_tokens.sql
@@ -1,0 +1,4 @@
+-- Prompt-cache hits per turn (spec 27). Nullable three ways: rows
+-- predating the column, and turns whose provider never reported
+-- prompt_tokens_details. NULL renders as "-", never zero.
+ALTER TABLE turns ADD COLUMN cached_tokens INTEGER;

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -12,9 +12,12 @@ use std::cmp::Ordering;
 use std::fmt::{self, Write as _};
 use std::sync::{Arc, Mutex};
 
+use std::collections::HashMap;
+
 use rusqlite::{Connection, params};
 
 use crate::agent::envelope::ChannelSource;
+use crate::config::ModelRates;
 use crate::state_db::StateDb;
 use tracing::warn;
 
@@ -91,13 +94,21 @@ pub struct TurnRecord<'a> {
 /// migration.
 pub struct UsageLedger {
     conn: Arc<Mutex<Connection>>,
+    /// Operator-supplied prices for the report's savings estimate;
+    /// carried here so command sites need no extra config plumbing.
+    rates: HashMap<String, ModelRates>,
 }
 
 impl UsageLedger {
-    pub fn new(db: &StateDb) -> Self {
+    pub fn new(db: &StateDb, rates: HashMap<String, ModelRates>) -> Self {
         Self {
             conn: db.connection(),
+            rates,
         }
+    }
+
+    pub fn rates(&self) -> &HashMap<String, ModelRates> {
+        &self.rates
     }
 
     /// Read every recorded turn, projected to the columns the report
@@ -211,6 +222,7 @@ impl Agg {
     /// Share of prompt tokens served from cache, over the rows that
     /// reported cache details; `None` when none did.
     fn cache_rate(&self) -> Option<f64> {
+        // Token sums sit far below f64's 2^53 integer ceiling.
         #[allow(clippy::cast_precision_loss)]
         (self.cached_prompt > 0).then(|| self.cached as f64 / self.cached_prompt as f64)
     }
@@ -333,11 +345,64 @@ fn write_task_table(out: &mut String, groups: &[(String, TaskAgg)]) {
     out.push('\n');
 }
 
+/// Estimated USD saved by prompt-cache hits: every cached token was
+/// billed at the cache-read rate instead of the input rate. Signed on
+/// purpose — a future policy whose cache costs exceed its savings must
+/// report that, not flatter itself. `None` until rates are configured
+/// and a row has recorded cache details. Rows whose model has no rate
+/// are counted, not skipped: silence would hide a misconfigured map.
+fn cache_savings(rows: &[TurnRow], rates: &HashMap<String, ModelRates>) -> Option<CacheSavings> {
+    if rates.is_empty() || rows.iter().all(|r| r.cached_tokens.is_none()) {
+        return None;
+    }
+    let mut savings = CacheSavings::default();
+    for row in rows {
+        let Some(cached) = row.cached_tokens else {
+            continue;
+        };
+        match rates.get(&row.model) {
+            // Token sums sit far below f64's 2^53 integer ceiling.
+            #[allow(clippy::cast_precision_loss)]
+            Some(rate) => {
+                savings.dollars +=
+                    cached as f64 * (rate.input_per_mtok - rate.cache_read_per_mtok) / 1e6;
+                savings.priced = true;
+            }
+            None => savings.unpriced_turns += 1,
+        }
+    }
+    Some(savings)
+}
+
+#[derive(Default)]
+struct CacheSavings {
+    dollars: f64,
+    /// At least one row's model had a configured rate.
+    priced: bool,
+    /// Rows with cache data but no rate for their model.
+    unpriced_turns: u64,
+}
+
+impl fmt::Display for CacheSavings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Cache savings: ")?;
+        match (self.priced, self.dollars < 0.0) {
+            (false, _) => write!(f, "-")?,
+            (true, true) => write!(f, "-${:.4}", -self.dollars)?,
+            (true, false) => write!(f, "${:.4}", self.dollars)?,
+        }
+        if self.unpriced_turns > 0 {
+            write!(f, " ({} turns unpriced)", self.unpriced_turns)?;
+        }
+        Ok(())
+    }
+}
+
 /// Render the `/usage` report: totals, the per-task headline, then the
 /// per-build and per-model breakdowns. By Task answers what a unit of
 /// work cost; By Build attributes a cost shift to the change that
 /// shipped it.
-pub fn report(rows: &[TurnRow]) -> String {
+pub fn report(rows: &[TurnRow], rates: &HashMap<String, ModelRates>) -> String {
     if rows.is_empty() {
         return "No usage recorded yet.".to_string();
     }
@@ -355,10 +420,14 @@ pub fn report(rows: &[TurnRow]) -> String {
         .map_or_else(String::new, |r| format!(", cache {}", fmt_rate(Some(r))));
     let _ = writeln!(
         out,
-        "Usage ({} turns, {}{cache})\n",
+        "Usage ({} turns, {}{cache})",
         total.turns,
         fmt_cost(total.cost, total.metered),
     );
+    if let Some(savings) = cache_savings(rows, rates) {
+        let _ = writeln!(out, "{savings}");
+    }
+    out.push('\n');
 
     write_task_table(&mut out, &group_by_task(rows));
 
@@ -494,6 +563,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let ledger = UsageLedger::new(
             &crate::state_db::StateDb::open(&dir.path().join("kitaebot.db")).unwrap(),
+            HashMap::new(),
         );
         (dir, ledger)
     }
@@ -726,6 +796,21 @@ mod tests {
         }
     }
 
+    /// The report without configured rates: no savings line.
+    fn report_no_rates(rows: &[TurnRow]) -> String {
+        report(rows, &HashMap::new())
+    }
+
+    fn glm_rates(input: f64, cache_read: f64) -> HashMap<String, ModelRates> {
+        HashMap::from([(
+            "glm".to_string(),
+            ModelRates {
+                input_per_mtok: input,
+                cache_read_per_mtok: cache_read,
+            },
+        )])
+    }
+
     /// A task-attributed row with timing, the post-spec-27 shape.
     fn task_row(task: &str, cost: f64, started_at: u64, duration_ms: u64) -> TurnRow {
         TurnRow {
@@ -739,7 +824,7 @@ mod tests {
 
     #[test]
     fn by_task_is_the_headline() {
-        let out = report(&[task_row("issue:o/r#1", 0.01, 100, 1_000)]);
+        let out = report_no_rates(&[task_row("issue:o/r#1", 0.01, 100, 1_000)]);
         let task = out.find("By Task").unwrap();
         let build = out.find("By Build").unwrap();
         assert!(task < build);
@@ -754,7 +839,7 @@ mod tests {
             task_row("issue:o/r#1", 0.01, 100, 60_000),
             task_row("issue:o/r#1", 0.02, 400, 120_000),
         ];
-        let out = report(&rows);
+        let out = report_no_rates(&rows);
         // Active: 1m + 2m; span: 100s..(400s + 120s) = 420s.
         assert!(out.contains("3m00s"), "active missing: {out}");
         assert!(out.contains("7m00s"), "span missing: {out}");
@@ -771,7 +856,7 @@ mod tests {
             row(Some("abcdef1234"), "glm", 100, Some(0.01)),
             task_row("duty:distill", 0.02, 100, 1_000),
         ];
-        let out = report(&rows);
+        let out = report_no_rates(&rows);
         let tracked = out.find("duty:distill").unwrap();
         let untracked = out.find("(untracked)").unwrap();
         assert!(tracked < untracked);
@@ -793,7 +878,7 @@ mod tests {
             .collect();
         // Re-touch the oldest task so recency puts it first.
         rows.push(task_row("issue:o/r#0", 0.01, 200, 1_000));
-        let out = report(&rows);
+        let out = report_no_rates(&rows);
         let first = out.find("issue:o/r#0 ").unwrap();
         let second = out
             .find(&format!("issue:o/r#{} ", TASK_GROUP_CAP + 1))
@@ -815,7 +900,7 @@ mod tests {
 
     #[test]
     fn report_empty_is_a_notice() {
-        assert_eq!(report(&[]), "No usage recorded yet.");
+        assert_eq!(report_no_rates(&[]), "No usage recorded yet.");
     }
 
     #[test]
@@ -825,7 +910,7 @@ mod tests {
             row(Some("abcdef1234"), "kimi", 500, Some(0.02)),
             row(Some("9999999999"), "glm", 2000, Some(0.05)),
         ];
-        let out = report(&rows);
+        let out = report_no_rates(&rows);
         // Header total: 3 turns, summed cost.
         assert!(out.contains("Usage (3 turns, $0.0800)"));
         // Short SHA, not the full hash.
@@ -846,7 +931,7 @@ mod tests {
             row(Some("aaaaaaa111"), "glm", 100, Some(0.90)),
             row(Some("bbbbbbb222"), "glm", 100, Some(0.01)),
         ];
-        let out = report(&rows);
+        let out = report_no_rates(&rows);
         let old = out.find("aaaaaaa").unwrap();
         let new = out.find("bbbbbbb").unwrap();
         assert!(old < new);
@@ -854,7 +939,7 @@ mod tests {
 
     #[test]
     fn report_unmetered_shows_dash() {
-        let out = report(&[row(None, "local", 10, None)]);
+        let out = report_no_rates(&[row(None, "local", 10, None)]);
         assert!(out.contains("Usage (1 turns, -)"));
         assert!(out.contains("unknown"));
     }
@@ -907,7 +992,7 @@ mod tests {
             },
             row(Some("9999999999"), "glm", 500, Some(0.01)),
         ];
-        let out = report(&rows);
+        let out = report_no_rates(&rows);
         assert!(out.contains("cache 75%"), "header rate missing: {out}");
         let cached_build = out
             .lines()
@@ -930,10 +1015,88 @@ mod tests {
         );
     }
 
+    /// 2M cached tokens at $0.40/M input vs $0.075/M cache read
+    /// saves 2 x $0.325 = $0.65.
+    #[test]
+    fn savings_priced_from_configured_rates() {
+        let rows = vec![
+            TurnRow {
+                cached_tokens: Some(1_500_000),
+                ..row(Some("abcdef1234"), "glm", 2_000_000, Some(0.5))
+            },
+            TurnRow {
+                cached_tokens: Some(500_000),
+                ..row(Some("abcdef1234"), "glm", 600_000, Some(0.2))
+            },
+        ];
+        let out = report(&rows, &glm_rates(0.4, 0.075));
+        assert!(out.contains("Cache savings: $0.6500"), "missing: {out}");
+        assert!(!out.contains("unpriced"), "nothing is unpriced: {out}");
+    }
+
+    /// The estimate is signed: rates where caching costs more than it
+    /// saves must show a negative number, not clamp to zero.
+    #[test]
+    fn savings_can_go_negative() {
+        let rows = vec![TurnRow {
+            cached_tokens: Some(1_000_000),
+            ..row(Some("abcdef1234"), "glm", 1_000_000, None)
+        }];
+        let out = report(&rows, &glm_rates(0.4, 0.5));
+        assert!(out.contains("Cache savings: -$0.1000"), "missing: {out}");
+    }
+
+    /// A model missing from the rates map is counted, not skipped:
+    /// silence would hide a misconfigured map behind a rosy number.
+    #[test]
+    fn savings_reports_unpriced_models() {
+        let rows = vec![
+            TurnRow {
+                cached_tokens: Some(1_000_000),
+                ..row(Some("abcdef1234"), "glm", 1_000_000, None)
+            },
+            TurnRow {
+                cached_tokens: Some(100),
+                ..row(Some("abcdef1234"), "kimi", 200, None)
+            },
+        ];
+        let out = report(&rows, &glm_rates(0.4, 0.075));
+        assert!(
+            out.contains("Cache savings: $0.3250 (1 turns unpriced)"),
+            "missing: {out}"
+        );
+        // Rates that price nothing still surface the row count.
+        let other = HashMap::from([(
+            "other-model".to_string(),
+            ModelRates {
+                input_per_mtok: 0.4,
+                cache_read_per_mtok: 0.075,
+            },
+        )]);
+        let none_priced = report(&rows, &other);
+        assert!(
+            none_priced.contains("Cache savings: - (2 turns unpriced)"),
+            "missing: {none_priced}"
+        );
+    }
+
+    /// No rates configured, or no rows with cache data: no line.
+    #[test]
+    fn savings_line_absent_without_rates_or_data() {
+        let cached = vec![TurnRow {
+            cached_tokens: Some(100),
+            ..row(Some("abcdef1234"), "glm", 200, None)
+        }];
+        assert!(!report_no_rates(&cached).contains("Cache savings"));
+        let uncached = vec![row(Some("abcdef1234"), "glm", 200, None)];
+        let out = report(&uncached, &glm_rates(0.4, 0.075));
+        assert!(!out.contains("Cache savings"), "no cache-era rows: {out}");
+    }
+
     /// A ledger with no cache-era rows keeps the old header shape.
     #[test]
     fn report_header_omits_cache_when_unmeasured() {
-        let out = report(&[row(Some("abcdef1234"), "glm", 100, Some(0.01))]);
+        let out = report_no_rates(&[row(Some("abcdef1234"), "glm", 100, Some(0.01))]);
         assert!(out.contains("Usage (1 turns, $0.0100)"));
         assert!(!out.contains("cache"));
     }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -228,9 +228,13 @@ impl Agg {
     }
 }
 
-/// `87%`, or `-` when the group has no measurable rows.
+/// `87%`, or `-` when the group has no measurable rows. Floored, not
+/// rounded: "100%" must mean every prompt token came from cache.
 fn fmt_rate(rate: Option<f64>) -> String {
-    rate.map_or_else(|| "-".to_string(), |r| format!("{:.0}%", r * 100.0))
+    rate.map_or_else(
+        || "-".to_string(),
+        |r| format!("{:.0}%", (r * 100.0).floor()),
+    )
 }
 
 /// Group turns by `key` in first-seen order. Rows arrive in insertion
@@ -888,6 +892,14 @@ mod tests {
             out.contains("(+2 more tasks)"),
             "cap trailer missing: {out}"
         );
+    }
+
+    #[test]
+    fn fmt_rate_floors_instead_of_rounding() {
+        // 1499/1500 is not a full cache hit; it must not display as one.
+        assert_eq!(fmt_rate(Some(1499.0 / 1500.0)), "99%");
+        assert_eq!(fmt_rate(Some(1.0)), "100%");
+        assert_eq!(fmt_rate(None), "-");
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -29,9 +29,9 @@ pub(crate) const SELECT_TURN_ROWS: &str =
 
 pub(crate) const INSERT_TURN: &str = "INSERT INTO turns
          (git_sha, session, source, model, task,
-          calls, prompt_tokens, completion_tokens, cost,
+          calls, prompt_tokens, cached_tokens, completion_tokens, cost,
           started_at, duration_ms, outcome)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)";
 
 /// The build's git revision, injected by the flake at compile time.
 /// `None` in plain `cargo` dev builds, where the env var is unset.
@@ -140,6 +140,7 @@ impl UsageLedger {
                 turn.task.map(TaskKey::as_str),
                 turn.meter.usage.calls,
                 turn.meter.usage.prompt_tokens.cast_signed(),
+                turn.meter.usage.cached_tokens.map(u64::cast_signed),
                 turn.meter.usage.completion_tokens.cast_signed(),
                 turn.meter.usage.cost,
                 turn.meter.started_at.cast_signed(),
@@ -480,6 +481,7 @@ mod tests {
                 meter: meter(TurnUsage {
                     calls: 3,
                     prompt_tokens: 1500,
+                    cached_tokens: Some(1200),
                     completion_tokens: 200,
                     cost: Some(0.0042),
                 }),
@@ -487,18 +489,19 @@ mod tests {
             .unwrap();
 
         let conn = ledger.conn.lock().unwrap();
-        let (session, source, model, calls, prompt, completion, cost): (
+        let (session, source, model, calls, prompt, cached, completion, cost): (
             String,
             String,
             String,
             i64,
             i64,
+            Option<i64>,
             i64,
             Option<f64>,
         ) = conn
             .query_row(
                 "SELECT session, source, model, calls, prompt_tokens, \
-                 completion_tokens, cost FROM turns",
+                 cached_tokens, completion_tokens, cost FROM turns",
                 [],
                 |r| {
                     Ok((
@@ -509,6 +512,7 @@ mod tests {
                         r.get(4)?,
                         r.get(5)?,
                         r.get(6)?,
+                        r.get(7)?,
                     ))
                 },
             )
@@ -518,6 +522,7 @@ mod tests {
         assert_eq!(model, "z-ai/glm-5.2");
         assert_eq!(calls, 3);
         assert_eq!(prompt, 1500);
+        assert_eq!(cached, Some(1200));
         assert_eq!(completion, 200);
         assert_eq!(cost, Some(0.0042));
     }
@@ -640,16 +645,21 @@ mod tests {
                 meter: meter(TurnUsage {
                     calls: 1,
                     prompt_tokens: 10,
+                    cached_tokens: None,
                     completion_tokens: 5,
                     cost: None,
                 }),
             })
             .unwrap();
         let conn = ledger.conn.lock().unwrap();
-        let cost: Option<f64> = conn
-            .query_row("SELECT cost FROM turns", [], |r| r.get(0))
+        let (cost, cached): (Option<f64>, Option<i64>) = conn
+            .query_row("SELECT cost, cached_tokens FROM turns", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
             .unwrap();
         assert_eq!(cost, None);
+        // Unreported cache details persist as NULL, never zero.
+        assert_eq!(cached, None);
     }
 
     #[test]
@@ -831,6 +841,7 @@ mod tests {
                 meter: meter(TurnUsage {
                     calls: 1,
                     prompt_tokens: 42,
+                    cached_tokens: Some(30),
                     completion_tokens: 8,
                     cost: Some(0.5),
                 }),

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -24,7 +24,7 @@ use crate::agent::TurnMeter;
 /// `state_db` can prepare every query against the migrated schema.
 pub(crate) const SELECT_TURN_ROWS: &str =
     "SELECT git_sha, model, prompt_tokens, completion_tokens, cost,
-            task, started_at, duration_ms
+            task, started_at, duration_ms, cached_tokens
          FROM turns ORDER BY id";
 
 pub(crate) const INSERT_TURN: &str = "INSERT INTO turns
@@ -118,6 +118,7 @@ impl UsageLedger {
                     task: r.get(5)?,
                     started_at: r.get::<_, Option<i64>>(6)?.map(i64::cast_unsigned),
                     duration_ms: r.get::<_, Option<i64>>(7)?.map(i64::cast_unsigned),
+                    cached_tokens: r.get::<_, Option<i64>>(8)?.map(i64::cast_unsigned),
                 })
             })?
             .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -174,6 +175,7 @@ pub struct TurnRow {
     pub task: Option<String>,
     pub started_at: Option<u64>,
     pub duration_ms: Option<u64>,
+    pub cached_tokens: Option<u64>,
 }
 
 /// Running totals over a group of turns.
@@ -185,6 +187,11 @@ struct Agg {
     /// At least one turn in the group reported a cost. When false the
     /// cost column shows "-": the provider never billed, so 0 would lie.
     metered: bool,
+    /// Prompt-cache hits, and the prompt tokens of only the rows that
+    /// reported them: the hit rate is computed over measurable rows,
+    /// so pre-0004 history cannot dilute it toward zero.
+    cached: u64,
+    cached_prompt: u64,
 }
 
 impl Agg {
@@ -195,7 +202,23 @@ impl Agg {
             self.cost += cost;
             self.metered = true;
         }
+        if let Some(cached) = row.cached_tokens {
+            self.cached += cached;
+            self.cached_prompt += row.prompt_tokens;
+        }
     }
+
+    /// Share of prompt tokens served from cache, over the rows that
+    /// reported cache details; `None` when none did.
+    fn cache_rate(&self) -> Option<f64> {
+        #[allow(clippy::cast_precision_loss)]
+        (self.cached_prompt > 0).then(|| self.cached as f64 / self.cached_prompt as f64)
+    }
+}
+
+/// `87%`, or `-` when the group has no measurable rows.
+fn fmt_rate(rate: Option<f64>) -> String {
+    rate.map_or_else(|| "-".to_string(), |r| format!("{:.0}%", r * 100.0))
 }
 
 /// Group turns by `key` in first-seen order. Rows arrive in insertion
@@ -325,9 +348,14 @@ pub fn report(rows: &[TurnRow]) -> String {
     }
 
     let mut out = String::new();
+    // The header carries the overall hit rate only once turns have
+    // recorded cache details; older ledgers keep the old shape.
+    let cache = total
+        .cache_rate()
+        .map_or_else(String::new, |r| format!(", cache {}", fmt_rate(Some(r))));
     let _ = writeln!(
         out,
-        "Usage ({} turns, {})\n",
+        "Usage ({} turns, {}{cache})\n",
         total.turns,
         fmt_cost(total.cost, total.metered),
     );
@@ -367,18 +395,19 @@ fn write_table(
     if per_turn {
         let _ = writeln!(
             out,
-            "{label:<24} {:>6} {:>10} {:>12} {:>10}",
-            "Turns", "Tokens", "Cost", "$/turn"
+            "{label:<24} {:>6} {:>10} {:>6} {:>12} {:>10}",
+            "Turns", "Tokens", "Cache", "Cost", "$/turn"
         );
     } else {
         let _ = writeln!(
             out,
-            "{label:<24} {:>6} {:>10} {:>12}",
-            "Turns", "Tokens", "Cost"
+            "{label:<24} {:>6} {:>10} {:>6} {:>12}",
+            "Turns", "Tokens", "Cache", "Cost"
         );
     }
     for (name, agg) in groups {
         let cost = fmt_cost(agg.cost, agg.metered);
+        let cache = fmt_rate(agg.cache_rate());
         if per_turn {
             let per = if agg.metered && agg.turns > 0 {
                 #[allow(clippy::cast_precision_loss)]
@@ -389,14 +418,14 @@ fn write_table(
             };
             let _ = writeln!(
                 out,
-                "{name:<24} {:>6} {:>10} {cost:>12} {per:>10}",
+                "{name:<24} {:>6} {:>10} {cache:>6} {cost:>12} {per:>10}",
                 agg.turns,
                 fmt_count(agg.tokens),
             );
         } else {
             let _ = writeln!(
                 out,
-                "{name:<24} {:>6} {:>10} {cost:>12}",
+                "{name:<24} {:>6} {:>10} {cache:>6} {cost:>12}",
                 agg.turns,
                 fmt_count(agg.tokens),
             );
@@ -693,6 +722,7 @@ mod tests {
             task: None,
             started_at: None,
             duration_ms: None,
+            cached_tokens: None,
         }
     }
 
@@ -850,8 +880,62 @@ mod tests {
         let rows = ledger.rows().unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].prompt_tokens, 42);
+        assert_eq!(rows[0].cached_tokens, Some(30));
         assert_eq!(rows[0].completion_tokens, 8);
         assert_eq!(rows[0].cost, Some(0.5));
+    }
+
+    /// The hit rate is computed over the rows that reported cache
+    /// details; a pre-0004 row in the same group must not dilute it.
+    #[test]
+    fn cache_rate_ignores_unreporting_rows() {
+        let mut agg = Agg::default();
+        agg.add(&TurnRow {
+            cached_tokens: Some(800),
+            ..row(Some("abcdef1234"), "glm", 1000, None)
+        });
+        agg.add(&row(Some("abcdef1234"), "glm", 500, None));
+        assert_eq!(agg.cache_rate(), Some(0.8));
+    }
+
+    #[test]
+    fn report_renders_cache_rate_per_group_and_header() {
+        let rows = vec![
+            TurnRow {
+                cached_tokens: Some(750),
+                ..row(Some("abcdef1234"), "glm", 1000, Some(0.01))
+            },
+            row(Some("9999999999"), "glm", 500, Some(0.01)),
+        ];
+        let out = report(&rows);
+        assert!(out.contains("cache 75%"), "header rate missing: {out}");
+        let cached_build = out
+            .lines()
+            .find(|l| l.starts_with("abcdef1"))
+            .unwrap()
+            .to_string();
+        assert!(
+            cached_build.contains("75%"),
+            "build rate missing: {cached_build}"
+        );
+        // The era without details renders absence, never 0%.
+        let uncached_build = out
+            .lines()
+            .find(|l| l.starts_with("9999999"))
+            .unwrap()
+            .to_string();
+        assert!(
+            uncached_build.contains('-'),
+            "expected dash: {uncached_build}"
+        );
+    }
+
+    /// A ledger with no cache-era rows keeps the old header shape.
+    #[test]
+    fn report_header_omits_cache_when_unmeasured() {
+        let out = report(&[row(Some("abcdef1234"), "glm", 100, Some(0.01))]);
+        assert!(out.contains("Usage (1 turns, $0.0100)"));
+        assert!(!out.contains("cache"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #104.

The provider parses `prompt_tokens_details.cached_tokens` from OpenRouter but logged it at debug level and dropped it, so nothing could say how much of a turn's prompt volume the cache absorbed. That number is the baseline the planned cache-economy work (#99, #100, #101) gets judged against.

Three commits, one layer each:

1. **Persist prompt-cache hits per turn** — carry the value through `CallUsage` and `TurnUsage` into a nullable `cached_tokens` column (migration 0004). `Option` end to end: a response without details means the provider did not say, distinct from a reported cold prompt of zero; NULL in the ledger, same contract as `cost`.
2. **Report the cache hit rate in /usage** — `Cache` column on By Build and By Model plus the overall rate in the header. The denominator is the prompt tokens of only the rows that recorded cache details, so pre-migration history cannot dilute the rate toward zero; unmeasured groups render `-`.
3. **Estimate cache savings from configured rates** — new `[usage.rates]` config (USD per 1M tokens per model id) prices cached tokens at the spread between input and cache-read rates. Signed, so a losing policy reports negative. Models missing from the map count as `(N turns unpriced)` rather than being skipped. Empty map (the default) omits the line.

Rates stay operator-supplied for now because the correct value depends on which OpenRouter endpoint sticky routing pinned; #109 covers recording the serving endpoint per turn and pricing from the live endpoint list.

Verify after deploy: any turn, then `/usage` — `Cache` column and header rate appear immediately; the savings line appears once `settings.usage.rates` carries real endpoint numbers.
