### PR TITLE
Price cache savings from OpenRouter's live endpoint rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ kitaebot = {
       max_iterations = 30;                       # Tool-loop cap per sub-agent turn
     };
     usage = {
-      rates = {                                  # USD per 1M tokens, for /usage cache savings (spec 27)
-        "z-ai/glm-5.2" = {
-          input_per_mtok = 0.4046;               # Rates vary by upstream endpoint; use your provider's
+      rates = {                                  # Optional overrides, USD per 1M tokens (spec 27).
+        "z-ai/glm-5.2" = {                       # On OpenRouter, /usage prices from the live per-endpoint
+          input_per_mtok = 0.4046;               # rates automatically; an entry here overrides them.
           cache_read_per_mtok = 0.07514;
         };
       };

--- a/specs/27-usage.md
+++ b/specs/27-usage.md
@@ -139,14 +139,23 @@ The header omits the rate entirely on an all-legacy ledger.
 
 Below the header, a `Cache savings` line estimates the USD saved by
 cache hits: cached tokens billed at the cache-read rate instead of
-the input rate, priced from operator-supplied `[usage.rates]` config
-(USD per million tokens per model id; rates vary by upstream
-endpoint, so they are never built in). The estimate is signed — a
-policy whose cache costs exceed its savings must report a negative
-number. Rows whose model has no configured rate are counted as
-`(N turns unpriced)` rather than skipped: silence would hide a
-misconfigured map. The line is absent when no rates are configured
-or no row has cache data.
+the input rate. Each row is priced by, in order: operator-supplied
+`[usage.rates]` config (USD per million tokens per model id — the
+override), then the live rate of the endpoint that served it,
+fetched at report time from OpenRouter's model-endpoints API and
+matched on the row's recorded `provider`. The fetch is best-effort
+garnish (5 s timeout, unauthenticated, same egress allowlist as the
+chat API): a failure degrades to config-then-unpriced, never to a
+failed report, and APIs without a pricing endpoint (including e2e
+fixture servers via `Custom`) never fetch. An endpoint that lists no
+cache-read price bills hits at the full input rate — a real spread
+of zero, kept, not dropped. Live rates are today's prices applied to
+historical rows; the recorded endpoint is what keeps the estimate
+grounded. The estimate is signed — a policy whose cache costs exceed
+its savings must report a negative number. Rows that resolve no rate
+are counted as `(N turns unpriced)` rather than skipped: silence
+would hide a misconfigured map. The line is absent when no rates
+exist from either source or no row has cache data.
 
 ## Boundaries
 

--- a/specs/27-usage.md
+++ b/specs/27-usage.md
@@ -48,6 +48,7 @@ The `turns` table in `state/kitaebot.db` (spec 05), migrations
 | `duration_ms` | 0003 | Wall time of the turn; NULL on legacy rows |
 | `outcome` | 0003 | Turn outcome label; NULL on legacy rows |
 | `cached_tokens` | 0004 | Prompt-cache hits, subset of `prompt_tokens`, summed over the calls that reported `prompt_tokens_details`; NULL when none did or on legacy rows |
+| `provider` | 0005 | Upstream endpoint that served the turn (OpenRouter response `provider` field), last seen across its calls; NULL when never named or on legacy rows |
 
 All post-baseline columns are nullable so both eras of rows parse.
 No index on `task`: the report reads the whole ledger by design and

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -272,7 +272,7 @@ struct TurnStats {
 /// A turn is many calls (one per tool-round), so a single call's
 /// numbers say nothing about the turn. This is the per-turn total the
 /// ledger records.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct TurnUsage {
     /// Provider calls made during the turn.
     pub calls: u32,
@@ -286,6 +286,10 @@ pub(crate) struct TurnUsage {
     /// Charged cost in USD, summed across calls; `None` when no call
     /// reported a cost (non-`OpenRouter`).
     pub cost: Option<f64>,
+    /// Endpoint that served the turn's calls, last seen wins: sticky
+    /// routing pins a session, so a mid-turn change is failover and
+    /// the newest endpoint is the one to price against.
+    pub provider: Option<String>,
 }
 
 impl TurnUsage {
@@ -300,6 +304,9 @@ impl TurnUsage {
         self.completion_tokens += u64::from(call.completion_tokens);
         if let Some(cost) = call.cost {
             self.cost = Some(self.cost.unwrap_or(0.0) + cost);
+        }
+        if call.provider.is_some() {
+            self.provider = call.provider;
         }
     }
 }
@@ -1110,6 +1117,7 @@ mod tests {
             cached_tokens: Some(80),
             completion_tokens: 20,
             cost: Some(0.001),
+            provider: None,
         });
         // A call with no usage still counts, contributes nothing else.
         usage.add_call(CallUsage::default());
@@ -1118,12 +1126,31 @@ mod tests {
             cached_tokens: Some(0),
             completion_tokens: 10,
             cost: Some(0.002),
+            provider: None,
         });
         assert_eq!(usage.calls, 3);
         assert_eq!(usage.prompt_tokens, 150);
         assert_eq!(usage.cached_tokens, Some(80));
         assert_eq!(usage.completion_tokens, 30);
         assert_eq!(usage.cost, Some(0.003));
+    }
+
+    /// Last seen wins, and a provider-less call (failover retry, or a
+    /// non-OpenRouter response) never erases a known endpoint.
+    #[test]
+    fn turn_usage_provider_keeps_last_seen() {
+        let mut usage = TurnUsage::default();
+        usage.add_call(CallUsage {
+            provider: Some("Sail Research".into()),
+            ..CallUsage::default()
+        });
+        usage.add_call(CallUsage::default());
+        assert_eq!(usage.provider.as_deref(), Some("Sail Research"));
+        usage.add_call(CallUsage {
+            provider: Some("Ambient".into()),
+            ..CallUsage::default()
+        });
+        assert_eq!(usage.provider.as_deref(), Some("Ambient"));
     }
 
     #[test]
@@ -1134,6 +1161,7 @@ mod tests {
             cached_tokens: None,
             completion_tokens: 5,
             cost: None,
+            provider: None,
         });
         assert_eq!(usage.calls, 1);
         assert_eq!(usage.cost, None);

--- a/src/clients/chat_completion.rs
+++ b/src/clients/chat_completion.rs
@@ -157,6 +157,10 @@ pub struct ChatResponse {
     /// adds cache details when usage accounting is requested.
     #[serde(default)]
     pub usage: Option<Usage>,
+    /// Upstream endpoint that served the call (`OpenRouter` only) —
+    /// the pricing and quantization identity behind sticky routing.
+    #[serde(default)]
+    pub provider: Option<String>,
 }
 
 /// Token usage reported by the provider.
@@ -237,6 +241,7 @@ mod tests {
             }],
             citations: Vec::new(),
             usage: None,
+            provider: None,
         })
         .unwrap()
     }

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -1,6 +1,7 @@
 pub mod chat_completion;
 pub mod github;
 pub mod linear;
+pub mod openrouter_pricing;
 pub mod telegram;
 
 /// Raw HTTP response at the IO/pure boundary.

--- a/src/clients/openrouter_pricing.rs
+++ b/src/clients/openrouter_pricing.rs
@@ -92,11 +92,24 @@ impl PricingClient {
 }
 
 /// Parse a raw endpoints response into per-endpoint rates. Pure.
+/// Status routing mirrors `chat_completion::interpret_response`: the
+/// error variant is the failure mode, not a catch-all label.
 fn interpret_pricing(raw: &RawResponse) -> Result<Vec<EndpointRates>, ProviderError> {
     debug!(status = raw.status, "Endpoint pricing response");
-    if !(200..=299).contains(&raw.status) {
-        let body = String::from_utf8_lossy(&raw.body);
-        return Err(ProviderError::BadRequest(format!("{}: {body}", raw.status)));
+    match raw.status {
+        200..=299 => {}
+        429 => return Err(ProviderError::RateLimited),
+        500..=599 => {
+            let body = String::from_utf8_lossy(&raw.body);
+            return Err(ProviderError::ServerError(format!(
+                "{}: {body}",
+                raw.status
+            )));
+        }
+        s => {
+            let body = String::from_utf8_lossy(&raw.body);
+            return Err(ProviderError::BadRequest(format!("{s}: {body}")));
+        }
     }
     let parsed: PricingResponse = serde_json::from_slice(&raw.body)
         .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
@@ -198,6 +211,24 @@ mod tests {
     fn non_2xx_is_an_error_carrying_the_body() {
         let err = interpret_pricing(&raw(404, "no such model")).unwrap_err();
         assert!(err.to_string().contains("404"), "{err}");
+    }
+
+    /// The variant names the failure mode: a rate limit or server
+    /// error must not be labeled a bad request.
+    #[test]
+    fn status_routes_to_the_matching_variant() {
+        assert!(matches!(
+            interpret_pricing(&raw(429, "")).unwrap_err(),
+            ProviderError::RateLimited
+        ));
+        assert!(matches!(
+            interpret_pricing(&raw(500, "boom")).unwrap_err(),
+            ProviderError::ServerError(s) if s.contains("boom")
+        ));
+        assert!(matches!(
+            interpret_pricing(&raw(404, "")).unwrap_err(),
+            ProviderError::BadRequest(_)
+        ));
     }
 
     #[tokio::test]

--- a/src/clients/openrouter_pricing.rs
+++ b/src/clients/openrouter_pricing.rs
@@ -1,0 +1,212 @@
+//! `OpenRouter` endpoint-pricing client (spec 27).
+//!
+//! `GET {base}/{model}/endpoints` lists every upstream endpoint
+//! serving a model with its prices. Unauthenticated, same host as the
+//! chat API, so it rides the existing egress allowlist. Pure parsing
+//! lives in [`interpret_pricing`]; IO is a stored closure, mirroring
+//! [`super::chat_completion::CompletionsClient`].
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tracing::{debug, error};
+
+use super::RawResponse;
+use crate::config::ModelRates;
+use crate::error::ProviderError;
+
+type GetResult = Result<RawResponse, ProviderError>;
+type GetFuture = Pin<Box<dyn Future<Output = GetResult> + Send>>;
+type GetFn = Arc<dyn Fn(String) -> GetFuture + Send + Sync>;
+
+/// Pricing lookups are report-side garnish; never let one hang /usage.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One upstream endpoint's identity and prices for a model.
+#[derive(Debug, PartialEq)]
+pub struct EndpointRates {
+    /// Matches the chat response's `provider` field.
+    pub provider_name: String,
+    pub rates: ModelRates,
+}
+
+/// Client for the `OpenRouter` model-endpoints pricing API.
+#[derive(Clone)]
+pub struct PricingClient {
+    get: GetFn,
+}
+
+impl PricingClient {
+    /// `base` is the models API root, e.g.
+    /// `https://openrouter.ai/api/v1/models`.
+    pub fn new(base: String) -> Self {
+        #[cfg(feature = "mock-network")]
+        super::assert_loopback(&base);
+        let client = super::http_client(reqwest::Client::builder().timeout(FETCH_TIMEOUT));
+        Self {
+            get: Arc::new(move |url| {
+                let client = client.clone();
+                let url = format!("{base}/{url}");
+                Box::pin(async move {
+                    let resp = client.get(&url).send().await.map_err(|e| {
+                        error!("Pricing fetch failed for {url}: {e}");
+                        ProviderError::Network(e.to_string())
+                    })?;
+                    let status = resp.status().as_u16();
+                    let bytes = resp.bytes().await.map_err(|e| {
+                        error!("Pricing body read failed for {url}: {e}");
+                        ProviderError::Network(e.to_string())
+                    })?;
+                    Ok(RawResponse {
+                        status,
+                        body: bytes.to_vec(),
+                        // Not plumbed: this client never retries.
+                        retry_after_secs: None,
+                    })
+                })
+            }),
+        }
+    }
+
+    /// Test constructor — inject an arbitrary closure keyed by the
+    /// path suffix (`<model>/endpoints`).
+    #[cfg(test)]
+    pub fn from_fn<F, Fut>(f: F) -> Self
+    where
+        F: Fn(String) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = GetResult> + Send + 'static,
+    {
+        Self {
+            get: Arc::new(move |path| Box::pin(f(path))),
+        }
+    }
+
+    /// Every endpoint currently serving `model`, with prices.
+    pub async fn endpoint_rates(&self, model: &str) -> Result<Vec<EndpointRates>, ProviderError> {
+        let raw = (self.get)(format!("{model}/endpoints")).await?;
+        interpret_pricing(&raw)
+    }
+}
+
+/// Parse a raw endpoints response into per-endpoint rates. Pure.
+fn interpret_pricing(raw: &RawResponse) -> Result<Vec<EndpointRates>, ProviderError> {
+    debug!(status = raw.status, "Endpoint pricing response");
+    if !(200..=299).contains(&raw.status) {
+        let body = String::from_utf8_lossy(&raw.body);
+        return Err(ProviderError::BadRequest(format!("{}: {body}", raw.status)));
+    }
+    let parsed: PricingResponse = serde_json::from_slice(&raw.body)
+        .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+    Ok(parsed
+        .data
+        .endpoints
+        .into_iter()
+        .filter_map(|e| {
+            let input_per_mtok = per_mtok(&e.pricing.prompt)?;
+            // No cache-read price means the endpoint bills cache hits
+            // at the full input rate: a real spread of zero, not a
+            // parse failure.
+            let cache_read_per_mtok = e
+                .pricing
+                .input_cache_read
+                .as_deref()
+                .and_then(per_mtok)
+                .unwrap_or(input_per_mtok);
+            Some(EndpointRates {
+                provider_name: e.provider_name,
+                rates: ModelRates {
+                    input_per_mtok,
+                    cache_read_per_mtok,
+                },
+            })
+        })
+        .collect())
+}
+
+/// The API prices in USD per token, as strings; config and the report
+/// speak USD per million tokens.
+fn per_mtok(per_token: &str) -> Option<f64> {
+    per_token.parse::<f64>().ok().map(|p| p * 1e6)
+}
+
+#[derive(Deserialize)]
+struct PricingResponse {
+    data: PricingData,
+}
+
+#[derive(Deserialize)]
+struct PricingData {
+    #[serde(default)]
+    endpoints: Vec<WireEndpoint>,
+}
+
+#[derive(Deserialize)]
+struct WireEndpoint {
+    provider_name: String,
+    pricing: WirePricing,
+}
+
+#[derive(Deserialize)]
+struct WirePricing {
+    prompt: String,
+    #[serde(default)]
+    input_cache_read: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(status: u16, body: &str) -> RawResponse {
+        RawResponse {
+            status,
+            body: body.as_bytes().to_vec(),
+            retry_after_secs: None,
+        }
+    }
+
+    /// Shape captured from the live API (2026-08-27).
+    const FIXTURE: &str = r#"{"data":{"id":"z-ai/glm-5.2","endpoints":[
+        {"provider_name":"Sail Research","context_length":1048576,
+         "pricing":{"prompt":"0.0000005","completion":"0.00000315","input_cache_read":"0.000000115"}},
+        {"provider_name":"Ambient",
+         "pricing":{"prompt":"0.0000006","completion":"0.000002"}}
+    ]}}"#;
+
+    #[test]
+    fn parses_endpoints_and_converts_to_per_mtok() {
+        let rates = interpret_pricing(&raw(200, FIXTURE)).unwrap();
+        assert_eq!(rates.len(), 2);
+        assert_eq!(rates[0].provider_name, "Sail Research");
+        assert!((rates[0].rates.input_per_mtok - 0.5).abs() < 1e-9);
+        assert!((rates[0].rates.cache_read_per_mtok - 0.115).abs() < 1e-9);
+    }
+
+    /// An endpoint without a cache-read price bills hits at the full
+    /// input rate: spread zero, present, not dropped.
+    #[test]
+    fn missing_cache_read_means_zero_spread() {
+        let rates = interpret_pricing(&raw(200, FIXTURE)).unwrap();
+        assert_eq!(rates[1].provider_name, "Ambient");
+        assert!((rates[1].rates.cache_read_per_mtok - rates[1].rates.input_per_mtok).abs() < 1e-9);
+    }
+
+    #[test]
+    fn non_2xx_is_an_error_carrying_the_body() {
+        let err = interpret_pricing(&raw(404, "no such model")).unwrap_err();
+        assert!(err.to_string().contains("404"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn client_requests_the_model_endpoint_path() {
+        let client = PricingClient::from_fn(|path| async move {
+            assert_eq!(path, "z-ai/glm-5.2/endpoints");
+            Ok(raw(200, FIXTURE))
+        });
+        let rates = client.endpoint_rates("z-ai/glm-5.2").await.unwrap();
+        assert_eq!(rates.len(), 2);
+    }
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -173,10 +173,13 @@ pub async fn execute(
         }
         SlashCommand::Usage => match usage_ledger {
             None => Ok(Reply::text("Usage tracking is disabled.".into())),
-            Some(ledger) => ledger
-                .rows()
-                .map(|rows| Reply::pre(usage::report(&rows, ledger.rates())))
-                .map_err(|e| format!("Usage query failed: {e}")),
+            Some(ledger) => match ledger.rows() {
+                Ok(rows) => {
+                    let live = ledger.live_rates(&rows).await;
+                    Ok(Reply::pre(usage::report(&rows, ledger.rates(), &live)))
+                }
+                Err(e) => Err(format!("Usage query failed: {e}")),
+            },
         },
         SlashCommand::Findings => match review_ledger {
             None => Ok(Reply::text("Review tracking is disabled.".into())),

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,7 +57,7 @@ pub struct UsageConfig {
 
 /// One model's input prices, in USD per million tokens. Rates vary by
 /// upstream endpoint, so these are operator-supplied, not built in.
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ModelRates {
     pub input_per_mtok: f64,
@@ -260,6 +260,16 @@ impl Api {
             Self::Together => "https://api.together.xyz/v1/chat/completions",
             Self::Mistral => "https://api.mistral.ai/v1/chat/completions",
             Self::Custom(url) => url,
+        }
+    }
+
+    /// Root of the model-endpoints pricing API, for APIs that have
+    /// one. `None` includes `Custom`: fixture servers serve chat, not
+    /// pricing, so e2e runs never fetch.
+    pub fn pricing_endpoint(&self) -> Option<&str> {
+        match self {
+            Self::OpenRouter => Some("https://openrouter.ai/api/v1/models"),
+            _ => None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,10 +390,14 @@ fn spawn_with_engine<E: ContextEngine + 'static>(
     // Telemetry: an open failure is logged and the daemon runs
     // unmetered and unrecorded. Opened before the task tool so
     // sub-agent turns share the ledgers.
-    let usage_ledger = Some(Arc::new(usage::UsageLedger::new(
-        state_db,
-        config.usage.rates.clone(),
-    )));
+    let usage_ledger = usage::UsageLedger::new(state_db, config.usage.rates.clone());
+    let usage_ledger = match config.provider.api.pricing_endpoint() {
+        Some(base) => usage_ledger.with_pricing(clients::openrouter_pricing::PricingClient::new(
+            base.to_string(),
+        )),
+        None => usage_ledger,
+    };
+    let usage_ledger = Some(Arc::new(usage_ledger));
     let review_ledger = config
         .review
         .enabled

--- a/src/provider/completions.rs
+++ b/src/provider/completions.rs
@@ -161,7 +161,14 @@ impl CompletionsProvider {
                 cached_tokens: u.prompt_tokens_details.as_ref().map(|d| d.cached_tokens),
                 completion_tokens: u.completion_tokens,
                 cost: u.cost,
+                provider: None,
             });
+        // The endpoint name rides the response root, not the usage
+        // block: a reply can name its endpoint even without usage.
+        let usage = CallUsage {
+            provider: response.provider.clone(),
+            ..usage
+        };
         Ok(ChatOutcome {
             response: Self::parse_response(response)?,
             usage,
@@ -289,6 +296,7 @@ mod tests {
             }],
             citations: Vec::new(),
             usage: None,
+            provider: None,
         }
     }
 
@@ -456,7 +464,8 @@ mod tests {
                 body: br#"{
                     "choices":[{"message":{"content":"hi"}}],
                     "usage":{"prompt_tokens":42,"completion_tokens":7,"cost":0.0013,
-                             "prompt_tokens_details":{"cached_tokens":30}}
+                             "prompt_tokens_details":{"cached_tokens":30}},
+                    "provider":"Sail Research"
                 }"#
                 .to_vec(),
                 retry_after_secs: None,
@@ -468,6 +477,28 @@ mod tests {
         assert_eq!(outcome.usage.cached_tokens, Some(30));
         assert_eq!(outcome.usage.completion_tokens, 7);
         assert_eq!(outcome.usage.cost, Some(0.0013));
+        assert_eq!(outcome.usage.provider.as_deref(), Some("Sail Research"));
+    }
+
+    /// The endpoint name rides the response root; it must survive
+    /// even when the response carries no usage block at all.
+    #[tokio::test]
+    async fn chat_captures_provider_without_usage() {
+        let client = CompletionsClient::from_fn(|_body| async {
+            Ok(crate::clients::RawResponse {
+                status: 200,
+                body: br#"{
+                    "choices":[{"message":{"content":"hi"}}],
+                    "provider":"Ambient"
+                }"#
+                .to_vec(),
+                retry_after_secs: None,
+            })
+        });
+        let provider = CompletionsProvider::new(client, &ProviderConfig::default());
+        let outcome = provider.chat("s", &[], &[]).await.unwrap();
+        assert_eq!(outcome.usage.prompt_tokens, None);
+        assert_eq!(outcome.usage.provider.as_deref(), Some("Ambient"));
     }
 
     /// Usage without `prompt_tokens_details` must surface cache hits

--- a/src/provider/mock.rs
+++ b/src/provider/mock.rs
@@ -58,7 +58,7 @@ impl Provider for MockProvider {
         *self.last_messages.lock().unwrap() = messages.to_vec();
         self.responses[index].clone().map(|response| ChatOutcome {
             response,
-            usage: self.usage,
+            usage: self.usage.clone(),
         })
     }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -27,7 +27,7 @@ pub struct ChatOutcome {
 }
 
 /// Per-call usage reported by the provider, when it reports any.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CallUsage {
     /// Prompt size as counted by the provider's tokenizer, when the API
     /// reports usage. Ground truth for context size — includes system
@@ -37,6 +37,9 @@ pub struct CallUsage {
     /// cache. `None` when the response carried no
     /// `prompt_tokens_details`; `Some(0)` is a reported cold prompt.
     pub cached_tokens: Option<u32>,
+    /// Upstream endpoint that served the call (`OpenRouter` names it
+    /// in every response). Decides which endpoint's rates apply.
+    pub provider: Option<String>,
     /// Tokens generated in the reply.
     pub completion_tokens: u32,
     /// Charged cost in USD; `OpenRouter` only, `None` elsewhere.

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -35,6 +35,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("state_db/migrations/0002_task.sql"),
     include_str!("state_db/migrations/0003_turn_timing.sql"),
     include_str!("state_db/migrations/0004_cached_tokens.sql"),
+    include_str!("state_db/migrations/0005_provider.sql"),
 ];
 
 /// Shared handle to the operational state database.

--- a/src/state_db/migrations/0005_provider.sql
+++ b/src/state_db/migrations/0005_provider.sql
@@ -1,0 +1,5 @@
+-- Upstream endpoint that served the turn (spec 27), last seen across
+-- its calls. Decides which endpoint's rates price the turn. Nullable:
+-- rows predating the column, and turns whose provider never named an
+-- endpoint. NULL renders as absence, never as a default endpoint.
+ALTER TABLE turns ADD COLUMN provider TEXT;

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -33,8 +33,8 @@ pub(crate) const SELECT_TURN_ROWS: &str =
 pub(crate) const INSERT_TURN: &str = "INSERT INTO turns
          (git_sha, session, source, model, task,
           calls, prompt_tokens, cached_tokens, completion_tokens, cost,
-          started_at, duration_ms, outcome)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)";
+          started_at, duration_ms, outcome, provider)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)";
 
 /// The build's git revision, injected by the flake at compile time.
 /// `None` in plain `cargo` dev builds, where the env var is unset.
@@ -158,6 +158,7 @@ impl UsageLedger {
                 turn.meter.started_at.cast_signed(),
                 duration_ms,
                 turn.meter.outcome,
+                turn.meter.usage.provider.as_deref(),
             ],
         )?;
         Ok(())
@@ -587,11 +588,16 @@ mod tests {
                     cached_tokens: Some(1200),
                     completion_tokens: 200,
                     cost: Some(0.0042),
+                    provider: Some("Sail Research".into()),
                 }),
             })
             .unwrap();
 
         let conn = ledger.conn.lock().unwrap();
+        let endpoint: Option<String> = conn
+            .query_row("SELECT provider FROM turns", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(endpoint.as_deref(), Some("Sail Research"));
         let (session, source, model, calls, prompt, cached, completion, cost): (
             String,
             String,
@@ -751,16 +757,19 @@ mod tests {
                     cached_tokens: None,
                     completion_tokens: 5,
                     cost: None,
+                    provider: None,
                 }),
             })
             .unwrap();
         let conn = ledger.conn.lock().unwrap();
-        let (cost, cached): (Option<f64>, Option<i64>) = conn
-            .query_row("SELECT cost, cached_tokens FROM turns", [], |r| {
-                Ok((r.get(0)?, r.get(1)?))
+        let (cost, cached, endpoint): (Option<f64>, Option<i64>, Option<String>) = conn
+            .query_row("SELECT cost, cached_tokens, provider FROM turns", [], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?))
             })
             .unwrap();
         assert_eq!(cost, None);
+        // An unnamed endpoint persists as NULL, never a default.
+        assert_eq!(endpoint, None);
         // Unreported cache details persist as NULL, never zero.
         assert_eq!(cached, None);
     }
@@ -971,6 +980,7 @@ mod tests {
                     cached_tokens: Some(30),
                     completion_tokens: 8,
                     cost: Some(0.5),
+                    provider: None,
                 }),
             })
             .unwrap();

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use rusqlite::{Connection, params};
 
 use crate::agent::envelope::ChannelSource;
+use crate::clients::openrouter_pricing::PricingClient;
 use crate::config::ModelRates;
 use crate::state_db::StateDb;
 use tracing::warn;
@@ -27,7 +28,7 @@ use crate::agent::TurnMeter;
 /// `state_db` can prepare every query against the migrated schema.
 pub(crate) const SELECT_TURN_ROWS: &str =
     "SELECT git_sha, model, prompt_tokens, completion_tokens, cost,
-            task, started_at, duration_ms, cached_tokens
+            task, started_at, duration_ms, cached_tokens, provider
          FROM turns ORDER BY id";
 
 pub(crate) const INSERT_TURN: &str = "INSERT INTO turns
@@ -97,6 +98,9 @@ pub struct UsageLedger {
     /// Operator-supplied prices for the report's savings estimate;
     /// carried here so command sites need no extra config plumbing.
     rates: HashMap<String, ModelRates>,
+    /// Live endpoint-pricing lookups; `None` when the API has no
+    /// pricing endpoint (non-`OpenRouter`, e2e fixtures).
+    pricing: Option<PricingClient>,
 }
 
 impl UsageLedger {
@@ -104,11 +108,55 @@ impl UsageLedger {
         Self {
             conn: db.connection(),
             rates,
+            pricing: None,
+        }
+    }
+
+    pub fn with_pricing(self, pricing: PricingClient) -> Self {
+        Self {
+            pricing: Some(pricing),
+            ..self
         }
     }
 
     pub fn rates(&self) -> &HashMap<String, ModelRates> {
         &self.rates
+    }
+
+    /// Live per-endpoint rates for the models these rows need priced,
+    /// keyed `(model, provider_name)`. Best-effort report garnish: no
+    /// client, a fetch failure, or an unknown model degrades to an
+    /// empty or partial map (the row then falls back to config rates
+    /// or counts as unpriced), never to a failed report.
+    pub async fn live_rates(&self, rows: &[TurnRow]) -> HashMap<(String, String), ModelRates> {
+        let mut out = HashMap::new();
+        let Some(pricing) = &self.pricing else {
+            return out;
+        };
+        // Only models with at least one priceable row: cache data plus
+        // a recorded endpoint, not already covered by config override.
+        let mut models: Vec<&str> = rows
+            .iter()
+            .filter(|r| {
+                r.cached_tokens.is_some()
+                    && r.provider.is_some()
+                    && !self.rates.contains_key(&r.model)
+            })
+            .map(|r| r.model.as_str())
+            .collect();
+        models.sort_unstable();
+        models.dedup();
+        for model in models {
+            match pricing.endpoint_rates(model).await {
+                Ok(endpoints) => {
+                    for e in endpoints {
+                        out.insert((model.to_string(), e.provider_name), e.rates);
+                    }
+                }
+                Err(e) => warn!("Endpoint pricing unavailable for {model}: {e}"),
+            }
+        }
+        out
     }
 
     /// Read every recorded turn, projected to the columns the report
@@ -130,6 +178,7 @@ impl UsageLedger {
                     started_at: r.get::<_, Option<i64>>(6)?.map(i64::cast_unsigned),
                     duration_ms: r.get::<_, Option<i64>>(7)?.map(i64::cast_unsigned),
                     cached_tokens: r.get::<_, Option<i64>>(8)?.map(i64::cast_unsigned),
+                    provider: r.get(9)?,
                 })
             })?
             .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -188,6 +237,7 @@ pub struct TurnRow {
     pub started_at: Option<u64>,
     pub duration_ms: Option<u64>,
     pub cached_tokens: Option<u64>,
+    pub provider: Option<String>,
 }
 
 /// Running totals over a group of turns.
@@ -350,14 +400,37 @@ fn write_task_table(out: &mut String, groups: &[(String, TaskAgg)]) {
     out.push('\n');
 }
 
+/// Live endpoint rates keyed by `(model, provider_name)`.
+pub type LiveRates = HashMap<(String, String), ModelRates>;
+
+/// The rate that prices one row. Operator config wins — it exists to
+/// override whatever the live list says — then the recorded serving
+/// endpoint's live rate; a row without a recorded endpoint has no
+/// live identity to price against.
+fn row_rates(
+    row: &TurnRow,
+    config: &HashMap<String, ModelRates>,
+    live: &LiveRates,
+) -> Option<ModelRates> {
+    if let Some(rate) = config.get(&row.model) {
+        return Some(*rate);
+    }
+    let provider = row.provider.as_ref()?;
+    live.get(&(row.model.clone(), provider.clone())).copied()
+}
+
 /// Estimated USD saved by prompt-cache hits: every cached token was
 /// billed at the cache-read rate instead of the input rate. Signed on
 /// purpose — a future policy whose cache costs exceed its savings must
-/// report that, not flatter itself. `None` until rates are configured
-/// and a row has recorded cache details. Rows whose model has no rate
-/// are counted, not skipped: silence would hide a misconfigured map.
-fn cache_savings(rows: &[TurnRow], rates: &HashMap<String, ModelRates>) -> Option<CacheSavings> {
-    if rates.is_empty() || rows.iter().all(|r| r.cached_tokens.is_none()) {
+/// report that, not flatter itself. `None` until any rates exist and a
+/// row has recorded cache details. Rows that resolve no rate are
+/// counted, not skipped: silence would hide a misconfigured map.
+fn cache_savings(
+    rows: &[TurnRow],
+    config: &HashMap<String, ModelRates>,
+    live: &LiveRates,
+) -> Option<CacheSavings> {
+    if (config.is_empty() && live.is_empty()) || rows.iter().all(|r| r.cached_tokens.is_none()) {
         return None;
     }
     let mut savings = CacheSavings::default();
@@ -365,7 +438,7 @@ fn cache_savings(rows: &[TurnRow], rates: &HashMap<String, ModelRates>) -> Optio
         let Some(cached) = row.cached_tokens else {
             continue;
         };
-        match rates.get(&row.model) {
+        match row_rates(row, config, live) {
             // Token sums sit far below f64's 2^53 integer ceiling.
             #[allow(clippy::cast_precision_loss)]
             Some(rate) => {
@@ -407,7 +480,7 @@ impl fmt::Display for CacheSavings {
 /// per-build and per-model breakdowns. By Task answers what a unit of
 /// work cost; By Build attributes a cost shift to the change that
 /// shipped it.
-pub fn report(rows: &[TurnRow], rates: &HashMap<String, ModelRates>) -> String {
+pub fn report(rows: &[TurnRow], rates: &HashMap<String, ModelRates>, live: &LiveRates) -> String {
     if rows.is_empty() {
         return "No usage recorded yet.".to_string();
     }
@@ -429,7 +502,7 @@ pub fn report(rows: &[TurnRow], rates: &HashMap<String, ModelRates>) -> String {
         total.turns,
         fmt_cost(total.cost, total.metered),
     );
-    if let Some(savings) = cache_savings(rows, rates) {
+    if let Some(savings) = cache_savings(rows, rates, live) {
         let _ = writeln!(out, "{savings}");
     }
     out.push('\n');
@@ -806,12 +879,13 @@ mod tests {
             started_at: None,
             duration_ms: None,
             cached_tokens: None,
+            provider: None,
         }
     }
 
     /// The report without configured rates: no savings line.
     fn report_no_rates(rows: &[TurnRow]) -> String {
-        report(rows, &HashMap::new())
+        report(rows, &HashMap::new(), &HashMap::new())
     }
 
     fn glm_rates(input: f64, cache_read: f64) -> HashMap<String, ModelRates> {
@@ -1051,7 +1125,7 @@ mod tests {
                 ..row(Some("abcdef1234"), "glm", 600_000, Some(0.2))
             },
         ];
-        let out = report(&rows, &glm_rates(0.4, 0.075));
+        let out = report(&rows, &glm_rates(0.4, 0.075), &HashMap::new());
         assert!(out.contains("Cache savings: $0.6500"), "missing: {out}");
         assert!(!out.contains("unpriced"), "nothing is unpriced: {out}");
     }
@@ -1064,7 +1138,7 @@ mod tests {
             cached_tokens: Some(1_000_000),
             ..row(Some("abcdef1234"), "glm", 1_000_000, None)
         }];
-        let out = report(&rows, &glm_rates(0.4, 0.5));
+        let out = report(&rows, &glm_rates(0.4, 0.5), &HashMap::new());
         assert!(out.contains("Cache savings: -$0.1000"), "missing: {out}");
     }
 
@@ -1082,7 +1156,7 @@ mod tests {
                 ..row(Some("abcdef1234"), "kimi", 200, None)
             },
         ];
-        let out = report(&rows, &glm_rates(0.4, 0.075));
+        let out = report(&rows, &glm_rates(0.4, 0.075), &HashMap::new());
         assert!(
             out.contains("Cache savings: $0.3250 (1 turns unpriced)"),
             "missing: {out}"
@@ -1095,11 +1169,116 @@ mod tests {
                 cache_read_per_mtok: 0.075,
             },
         )]);
-        let none_priced = report(&rows, &other);
+        let none_priced = report(&rows, &other, &HashMap::new());
         assert!(
             none_priced.contains("Cache savings: - (2 turns unpriced)"),
             "missing: {none_priced}"
         );
+    }
+
+    fn live(model: &str, endpoint: &str, input: f64, cache_read: f64) -> LiveRates {
+        HashMap::from([(
+            (model.to_string(), endpoint.to_string()),
+            ModelRates {
+                input_per_mtok: input,
+                cache_read_per_mtok: cache_read,
+            },
+        )])
+    }
+
+    /// Live rates price a row by the endpoint that served it; config,
+    /// when present for the model, overrides the live number.
+    #[test]
+    fn live_rates_price_by_serving_endpoint_config_overrides() {
+        let rows = vec![TurnRow {
+            cached_tokens: Some(1_000_000),
+            provider: Some("Sail Research".into()),
+            ..row(Some("abcdef1234"), "glm", 1_000_000, None)
+        }];
+        let live = live("glm", "Sail Research", 0.5, 0.115);
+        let out = report(&rows, &HashMap::new(), &live);
+        assert!(out.contains("Cache savings: $0.3850"), "live: {out}");
+        // Config says otherwise; config wins.
+        let out = report(&rows, &glm_rates(0.4, 0.075), &live);
+        assert!(out.contains("Cache savings: $0.3250"), "override: {out}");
+    }
+
+    /// A row that never recorded its endpoint has no live identity to
+    /// price against: unpriced, not silently matched to some endpoint.
+    #[test]
+    fn live_rates_skip_rows_without_a_recorded_endpoint() {
+        let rows = vec![TurnRow {
+            cached_tokens: Some(100),
+            provider: None,
+            ..row(Some("abcdef1234"), "glm", 200, None)
+        }];
+        let out = report(
+            &rows,
+            &HashMap::new(),
+            &live("glm", "Sail Research", 0.5, 0.115),
+        );
+        assert!(
+            out.contains("Cache savings: - (1 turns unpriced)"),
+            "missing: {out}"
+        );
+    }
+
+    /// `live_rates` fetches only models that need pricing: cache data,
+    /// a recorded endpoint, and no config override.
+    #[tokio::test]
+    async fn live_rates_fetches_only_unpriced_models() {
+        use crate::clients::openrouter_pricing::PricingClient;
+        let dir = tempfile::tempdir().unwrap();
+        let db = crate::state_db::StateDb::open(&dir.path().join("kitaebot.db")).unwrap();
+        let ledger = UsageLedger::new(&db, glm_rates(0.4, 0.075)).with_pricing(
+            PricingClient::from_fn(|path| async move {
+                assert_eq!(path, "kimi/endpoints", "only kimi needs live rates");
+                Ok(crate::clients::RawResponse {
+                    status: 200,
+                    body: br#"{"data":{"endpoints":[{"provider_name":"Moonshot",
+                        "pricing":{"prompt":"0.000001","input_cache_read":"0.0000001"}}]}}"#
+                        .to_vec(),
+                    retry_after_secs: None,
+                })
+            }),
+        );
+        let rows = vec![
+            // Config-covered: no fetch.
+            TurnRow {
+                cached_tokens: Some(10),
+                provider: Some("Sail Research".into()),
+                ..row(None, "glm", 20, None)
+            },
+            // No endpoint recorded: nothing to price against, no fetch.
+            TurnRow {
+                cached_tokens: Some(10),
+                ..row(None, "local", 20, None)
+            },
+            TurnRow {
+                cached_tokens: Some(10),
+                provider: Some("Moonshot".into()),
+                ..row(None, "kimi", 20, None)
+            },
+        ];
+        let fetched = ledger.live_rates(&rows).await;
+        assert_eq!(fetched.len(), 1);
+        let rate = fetched
+            .get(&("kimi".to_string(), "Moonshot".to_string()))
+            .unwrap();
+        assert!((rate.input_per_mtok - 1.0).abs() < 1e-9);
+    }
+
+    /// Without a pricing client (non-`OpenRouter`, tests), live rates
+    /// are empty and the report falls back to config alone.
+    #[tokio::test]
+    async fn live_rates_empty_without_a_client() {
+        let (_dir, ledger) = open_temp();
+        let rows = vec![TurnRow {
+            cached_tokens: Some(10),
+            provider: Some("Sail Research".into()),
+            ..row(None, "glm", 20, None)
+        }];
+        assert!(ledger.live_rates(&rows).await.is_empty());
     }
 
     /// No rates configured, or no rows with cache data: no line.
@@ -1111,7 +1290,7 @@ mod tests {
         }];
         assert!(!report_no_rates(&cached).contains("Cache savings"));
         let uncached = vec![row(Some("abcdef1234"), "glm", 200, None)];
-        let out = report(&uncached, &glm_rates(0.4, 0.075));
+        let out = report(&uncached, &glm_rates(0.4, 0.075), &HashMap::new());
         assert!(!out.contains("Cache savings"), "no cache-era rows: {out}");
     }
 


### PR DESCRIPTION
Closes #109.

The cache-savings line (#111) priced cached tokens from hand-maintained `[usage.rates]` config, but a single per-model number is a guess: OpenRouter's per-endpoint spread for GLM 5.2 alone runs $0.50 to $0.68 per million input tokens, and which endpoint applies is decided by sticky session routing. Both halves of the real answer are available: every chat response names its serving endpoint in a `provider` field, and `GET /api/v1/models/{model}/endpoints` lists each endpoint's prices, unauthenticated, on a host already egress-allowlisted.

Two commits:

1. **Record the serving endpoint per turn** — parse the response's `provider` field through `CallUsage`/`TurnUsage` (last-seen-wins: a mid-turn endpoint change is failover, and a provider-less call never erases a known name) into a nullable `provider` column (migration 0005). Independently useful: it surfaces whether traffic is landing on a degraded-quantization endpoint. `CallUsage`/`TurnUsage` lose `Copy` for the `String`; all use sites already moved by value.
2. **Price rows from the live endpoint list** — `/usage` fetches endpoint pricing for each model that needs it (has cache data, has a recorded endpoint, no config entry) and prices each row by its `(model, provider)` pair. Resolution order: config override → live endpoint rate → `(N turns unpriced)`. Fetch failure degrades to config-then-unpriced with a warning, never a failed report; `Api::Custom` returns no pricing endpoint, so e2e fixture runs never fetch. An endpoint listing no cache-read price bills hits at the full input rate — kept as a real spread of zero, not dropped.

Accepted imprecision, stated in spec 27: live rates are today's prices applied to historical rows — same limitation config had; the recorded endpoint is what keeps the estimate grounded.

After deploy: nothing to configure. The savings line prices itself for turns recorded after migration 0005; `[usage.rates]` becomes a pure override knob.
