### PR TITLE
Trust devshell-signed exports over stderr noise

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -517,11 +517,15 @@ parallel tool calls each trigger a full `nix print-dev-env` evaluation.
    timeout
 4. **Detect silent flake failures** — `direnv export json` exits 0
    even when `use flake` fails, printing the nix error to stderr and
-   exporting a bare environment. The cache checks stderr for nix's
-   `error:` marker (after stripping ANSI color codes) and treats a
-   match as a failure carrying the stderr, so the real error surfaces
-   in the duty outcome rather than as a `command not found` from bare
-   PATH.
+   exporting a bare environment. The cache classifies by the export
+   first: an export carrying a nix devshell signature (`IN_NIX_SHELL`
+   or `NIX_STORE`) proves the flake evaluated and succeeds regardless
+   of stderr noise, since shellHook steps (just, pnpm, cargo) also
+   print `error:`-prefixed lines without breaking the devshell. A
+   signature-less export falls back to checking stderr for nix's
+   `error:` marker (after stripping ANSI color codes); a match is a
+   failure carrying the stderr, so the real error surfaces in the
+   duty outcome rather than as a `command not found` from bare PATH.
 5. **Graceful degradation** — if direnv fails, exec runs without the devshell
 6. **Warm on clone** — `git_clone` pre-populates the cache in the background
 7. **Trust before evaluate** — `git_clone` runs `direnv allow` synchronously

--- a/src/tools/direnv.rs
+++ b/src/tools/direnv.rs
@@ -382,7 +382,10 @@ async fn evaluate_direnv(
 
     // A devshell signature var proves the flake evaluated: nix always
     // exports IN_NIX_SHELL and NIX_STORE from a live devshell, and a
-    // failed evaluation has no devshell environment to export.
+    // failed evaluation has no devshell environment to export. The
+    // subprocess env is env_clear()ed to SAFE_ENV_VARS, which contains
+    // neither var, so the export diff can never omit them as already
+    // present in the parent.
     if !has_devshell_signature(&env) {
         // direnv swallows `use flake` failures, exporting a bare
         // environment; nix's `error:` marker on stderr is the tell.

--- a/src/tools/direnv.rs
+++ b/src/tools/direnv.rs
@@ -363,18 +363,6 @@ async fn evaluate_direnv(
         )));
     }
 
-    // direnv swallows `use flake` failures: it exits 0, prints the nix
-    // error to stderr, and exports a bare environment. Detect this by
-    // checking for nix's `error:` marker on stderr (after stripping ANSI
-    // color codes). On success stderr carries only direnv log messages
-    // (prefixed `direnv:`), which never start with `error:`.
-    let stderr = output.stderr.trim();
-    if has_nix_error(stderr) {
-        return Err(DirenvError::Failed(format!(
-            "direnv export json reported an error: {stderr}"
-        )));
-    }
-
     // direnv outputs nothing when there's no .envrc or it's not allowed.
     let stdout = output.stdout.trim();
     if stdout.is_empty() {
@@ -387,13 +375,32 @@ async fn evaluate_direnv(
 
     // Filter out nulls (variables direnv wants to unset — irrelevant since
     // we build the subprocess env from scratch, not from the current process).
-    let env = raw
+    let env: HashMap<String, String> = raw
         .into_iter()
         .filter_map(|(k, v)| v.map(|v| (k, v)))
         .collect();
 
+    // A devshell signature var proves the flake evaluated: nix always
+    // exports IN_NIX_SHELL and NIX_STORE from a live devshell, and a
+    // failed evaluation has no devshell environment to export.
+    if !has_devshell_signature(&env) {
+        // direnv swallows `use flake` failures, exporting a bare
+        // environment; nix's `error:` marker on stderr is the tell.
+        let stderr = output.stderr.trim();
+        if has_nix_error(stderr) {
+            return Err(DirenvError::Failed(format!(
+                "direnv export json reported an error: {stderr}"
+            )));
+        }
+    }
+
     debug!(dir = %dir.display(), "Direnv evaluation complete");
     Ok(env)
+}
+
+/// Whether the export carries proof that a nix devshell evaluated.
+fn has_devshell_signature(env: &HashMap<String, String>) -> bool {
+    env.contains_key("IN_NIX_SHELL") || env.contains_key("NIX_STORE")
 }
 
 #[cfg(test)]
@@ -746,6 +753,49 @@ mod tests {
             env.get("PATH").map(String::as_str),
             Some("/nix/store/bin"),
             "direnv log messages on stderr must not cause a false failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_trusts_devshell_export_despite_hook_error_line() {
+        // The #114 incident: a devshell evaluates fully (signature
+        // vars exported) but its shellHook contains a non-fatal
+        // failing step whose tool prints an `error:`-prefixed line
+        // (just's recipe format). The working export must win.
+        let fake = FakeDirenv::install(
+            "echo 'error: recipe `pnpm-install` failed on line 19 with exit code 1' >&2\necho '{\"IN_NIX_SHELL\": \"impure\", \"NIX_STORE\": \"/nix/store\", \"PATH\": \"/nix/store/bin\"}'",
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".envrc"), "use flake").unwrap();
+
+        let cache = fake.cache();
+        let env = cache.get(dir.path()).await.unwrap().unwrap();
+        assert_eq!(
+            env.get("PATH").map(String::as_str),
+            Some("/nix/store/bin"),
+            "a signature-bearing export must not be failed on shellHook noise"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_fails_manual_export_without_signature_and_nix_error() {
+        // An .envrc that sets variables before a failing `use flake`
+        // (the `export NIX_CONFIG=...` pattern) exports non-empty but
+        // carries no devshell signature — the nix error must still
+        // classify it Failed (#41 semantics preserved).
+        let fake = FakeDirenv::install(
+            "echo 'error: Failed to fetch git repository' >&2\necho '{\"NIX_CONFIG\": \"extra-experimental-features =\"}'",
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".envrc"), "use flake").unwrap();
+
+        let cache = fake.cache();
+        let err = cache.get(dir.path()).await.unwrap_err();
+        assert!(
+            matches!(&err, DirenvError::Failed(m) if m.contains("Failed to fetch")),
+            "signature-less export with a nix error must stay Failed: {err}"
         );
     }
 }


### PR DESCRIPTION
Closes #114.

The stderr `error:` check in `evaluate_direnv` ran before the export was parsed, so any shellHook step printing an `error:`-prefixed line (just, pnpm, cargo all do) failed a fully-working devshell. Fast failures are uncached by design, so every git call re-ran the entire devshell evaluation: eight full pnpm-install passes in 37 seconds observed on CumuloGlobal/lightning-node, whose hook tolerates a failing prisma postinstall and still reaches "Development environment ready" with a complete export.

Classification now keys on the authoritative artifact — the export: a nix devshell signature (`IN_NIX_SHELL` or `NIX_STORE`) is present iff the flake actually evaluated, so a signature-bearing export succeeds regardless of stderr noise. Signature-less exports keep the #41 stderr fallback unchanged (bare export + nix `error:` line → `Failed`), which also covers an `.envrc` that sets variables before a failing `use flake`. Verified against the real kitaebot flake: its successful export carries 74 keys including both signature vars, with clean stderr.

Implements the approved plan on #114 (comment 5447407609). The issue's option 3 (`Failed` TTL) was deliberately deferred per plan decision 3. Spec 03 requirement 4 reworded to the signature-first contract; failure-caching semantics (requirement 3) untouched.

Validation: all 25 `tools::direnv` tests pass, including two new ones — the incident shape (signature + just error line → `Ready`) and the regression shape (manual export, no signature, nix error → `Failed`). `nix flake check` passed at commit time (cargo-deny duplicate-crate warnings are pre-existing). The 32 `tools::git::fixup`/`rebase` failures in the in-sandbox suite are pre-existing on master (verified with the change stashed); the nix gate runs them green.