### PR TITLE
Plan/execute split: planner model thinks, flash default executes

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ kitaebot = {
         worker.model = "mid/model";
         summarizer.model = "cheap/model";          # Fresh-path summaries only; live compaction rides the main model's cache (spec 14)
         reviewer.model = "strong/model";           # Judges the bot's own work and others' PRs
+        planner.model = "strong/model";            # Plan turns think here; keep distinct from reviewer (the judge must not be the author)
         memory = {                                 # Distilled facts persist and inject every turn; don't skimp
           model = "strong/model";
           reasoning.effort = "low";                # Reasoning spirals starve content room; bound the thinking

--- a/deploy/configuration.nix
+++ b/deploy/configuration.nix
@@ -58,7 +58,9 @@ in
     };
     settings = {
       provider = {
-        model = "z-ai/glm-5.3";
+        # The execution default (spec 25 plan/execute split): plan
+        # turns think on model_overrides.planner below.
+        model = "z-ai/glm-5.3-flash";
         max_tokens = 32768;
         # Unset lets glm-5.3 free-run its thinking: 5.4x the output
         # tokens per call that 5.2 produced, on every iteration.
@@ -68,7 +70,12 @@ in
           worker.model = "deepseek/deepseek-v4-pro";
           reviewer.model = "moonshotai/kimi-k3";
           summarizer.model = "deepseek/deepseek-v4-flash";
+          # Distilled facts persist and inject into every future turn;
+          # they must not inherit the flash default.
+          memory.model = "z-ai/glm-5.3";
           memory.reasoning.effort = "low";
+          # Not kimi: the plan gate's judge must not be the author.
+          planner.model = "z-ai/glm-5.3";
         };
       };
 

--- a/specs/02-provider.md
+++ b/specs/02-provider.md
@@ -176,6 +176,7 @@ Configuration via `config.toml` under `[provider]`:
 | `model_overrides.reviewer` | unset | Override for `reviewer` sub-agents (spec 23) |
 | `model_overrides.summarizer` | unset | Override for compaction summaries |
 | `model_overrides.memory` | unset | Override for memory distillation turns |
+| `model_overrides.planner` | unset | Override for plan turns (spec 25 plan/execute split); unset routes them to the default like every other turn |
 
 Each `model_overrides.*` value is a table setting `model`,
 `reasoning`, or both (`worker = { model = "cheap/model" }`;

--- a/specs/25-github-issues.md
+++ b/specs/25-github-issues.md
@@ -94,7 +94,12 @@ This is the plan/execute split: the thinking phase gets the strong
 model, and a strong reviewed plan is what lets the default be cheap.
 Revisions run on the default deliberately; a revised plan still passes
 the plan gate, and the channel cannot tell approval from feedback
-before dispatch. Unset, every turn routes identically.
+before dispatch. Unset, every turn routes identically. The plan
+format ends with an executor-facing "Implementation notes" section —
+files, verify commands, ordering constraints, landmines — because the
+executing model may be weaker than the planning one and must not be
+left re-deriving what the planner already knew; reviewers can stop
+reading above that line, and the plan gate reviews it with the rest.
 
 **The plan rides the dispatch.** When the recorded plan comment is in
 the tick's fetched thread, post-plan dispatches embed its body

--- a/specs/25-github-issues.md
+++ b/specs/25-github-issues.md
@@ -86,6 +86,16 @@ dispatch waived it (the waiver covers settled ground only; the bot can
 raise its own hand). The label is read at announcement time; adding it
 later changes nothing.
 
+**Plan turns think on the planner model.** A plan announcement
+dispatches with the planner turn role, served by
+`model_overrides.planner` when set (spec 02); execution, discussion,
+and post-plan comment turns — revisions included — ride the default.
+This is the plan/execute split: the thinking phase gets the strong
+model, and a strong reviewed plan is what lets the default be cheap.
+Revisions run on the default deliberately; a revised plan still passes
+the plan gate, and the channel cannot tell approval from feedback
+before dispatch. Unset, every turn routes identically.
+
 **Plan revisions edit in place.** The channel records the announcement
 reply's comment id (that comment is the plan) and hands it to
 revision turns, which are instructed to engage with feedback as a

--- a/specs/25-github-issues.md
+++ b/specs/25-github-issues.md
@@ -96,6 +96,16 @@ Revisions run on the default deliberately; a revised plan still passes
 the plan gate, and the channel cannot tell approval from feedback
 before dispatch. Unset, every turn routes identically.
 
+**The plan rides the dispatch.** When the recorded plan comment is in
+the tick's fetched thread, post-plan dispatches embed its body
+verbatim. Session history is not relied on: after compaction the
+assembled prompt holds a summary of the plan, not the plan (LCM keeps
+the bytes but recovery is a tool round the model must initiate; flat
+summarizes lossily), and the execution turn — the cheap-default half
+of the plan/execute split — must see the gate-reviewed text
+unconditionally. A plan past the fetch cap or deleted degrades to the
+id reference alone.
+
 **Plan revisions edit in place.** The channel records the announcement
 reply's comment id (that comment is the plan) and hands it to
 revision turns, which are instructed to engage with feedback as a

--- a/specs/26-linear.md
+++ b/specs/26-linear.md
@@ -51,7 +51,10 @@ issues channel ([spec 25](25-github-issues.md)): an issue carrying
 `linear.plan_label` (default `needs-plan`, case-insensitive) gets
 plan-first; without it the announcement is a direct execution turn,
 with the same judgment backstop. The label is read at announcement
-time.
+time. Plan announcements dispatch with the planner turn role, exactly
+as on GitHub (spec 25's plan/execute split): both ticket channels'
+plans think on `model_overrides.planner`, everything else on the
+default.
 
 **Repo selection**: the target repository comes from a label on the issue —
 a label named like `owner/repo` (contains exactly one `/`). Issues without

--- a/specs/26-linear.md
+++ b/specs/26-linear.md
@@ -51,10 +51,13 @@ issues channel ([spec 25](25-github-issues.md)): an issue carrying
 `linear.plan_label` (default `needs-plan`, case-insensitive) gets
 plan-first; without it the announcement is a direct execution turn,
 with the same judgment backstop. The label is read at announcement
-time. Plan announcements dispatch with the planner turn role, exactly
-as on GitHub (spec 25's plan/execute split): both ticket channels'
-plans think on `model_overrides.planner`, everything else on the
-default.
+time. Plan announcements dispatch with the planner turn role, as on
+GitHub (spec 25's plan/execute split): both ticket channels' plans
+think on `model_overrides.planner`, everything else on the default.
+Routing parity only: GitHub's other half — the recorded plan comment
+embedded verbatim in post-plan dispatches — is not yet ported, so a
+Linear execution turn still relies on the plan surviving session
+context.
 
 **Repo selection**: the target repository comes from a label on the issue —
 a label named like `owner/repo` (contains exactly one `/`). Issues without

--- a/src/agent/actor.rs
+++ b/src/agent/actor.rs
@@ -25,7 +25,7 @@ use crate::workspace::Workspace;
 use tokio::sync::mpsc;
 
 use super::PromptConfig;
-use super::envelope::{ChannelSource, Envelope, InputEnvelope};
+use super::envelope::{ChannelSource, Envelope, InputEnvelope, TurnRole};
 
 /// The actor that processes envelopes sequentially.
 ///
@@ -34,6 +34,9 @@ pub(super) struct Agent<P: Provider, E: ContextEngine> {
     rx: mpsc::Receiver<Envelope>,
     workspace: Arc<Workspace>,
     provider: Arc<P>,
+    /// Serves [`TurnRole::Planner`] turns; the default provider when
+    /// no `model_overrides.planner` is configured.
+    planner_provider: Arc<P>,
     memory_provider: Arc<P>,
     tools: Arc<Tools>,
     distiller: Arc<Distiller>,
@@ -55,6 +58,7 @@ impl<P: Provider + 'static, E: ContextEngine + 'static> Agent<P, E> {
         rx: mpsc::Receiver<Envelope>,
         workspace: Arc<Workspace>,
         provider: Arc<P>,
+        planner_provider: Arc<P>,
         memory_provider: Arc<P>,
         tools: Arc<Tools>,
         distiller: Arc<Distiller>,
@@ -71,6 +75,7 @@ impl<P: Provider + 'static, E: ContextEngine + 'static> Agent<P, E> {
             rx,
             workspace,
             provider,
+            planner_provider,
             memory_provider,
             tools,
             distiller,
@@ -282,12 +287,18 @@ impl<P: Provider + 'static, E: ContextEngine + 'static> Agent<P, E> {
         // Derived once for both the ToolCtx and the ledger row, so the
         // sub-agent inheritance and the root attribution cannot diverge.
         let task = TaskKey::for_source(&envelope.source);
+        // Selected once for both the turn and the ledger row, so the
+        // billed model can never disagree with the one that ran.
+        let provider: &P = match envelope.role {
+            TurnRole::Default => &self.provider,
+            TurnRole::Planner => &self.planner_provider,
+        };
         let metered = super::process_message_metered(
             &mut self.engine,
             &self.summarize,
             &self.workspace,
             &tagged,
-            &*self.provider,
+            provider,
             &self.tools,
             self.max_iterations,
             &self.prompt,
@@ -309,7 +320,7 @@ impl<P: Provider + 'static, E: ContextEngine + 'static> Agent<P, E> {
             &TurnRecord {
                 session: target,
                 source: &source,
-                model: self.provider.model(),
+                model: provider.model(),
                 task: Some(&task),
                 meter,
             },
@@ -998,6 +1009,47 @@ mod tests {
 
         assert_eq!(result.unwrap().content, "Distillation gate closed.");
         assert_eq!(root.call_count(), 0);
+    }
+
+    /// Planner turns run on the planner provider, default turns on the
+    /// root — the selection the spec 25 plan/execute split rides on.
+    #[tokio::test]
+    async fn turn_role_selects_the_provider() {
+        let (_dir, ws) = crate::test_support::workspace();
+        let root = Arc::new(MockProvider::new(vec![Ok(Response::Text("root".into()))]));
+        let planner = Arc::new(MockProvider::new(vec![Ok(Response::Text("plan".into()))]));
+        let handle = TestAgent::new(ws, root.clone())
+            .planner(planner.clone())
+            .spawn();
+
+        let reply = handle
+            .send_message_with_role(
+                ChannelSource::Socket,
+                "plan this".into(),
+                None,
+                None,
+                CancellationToken::new(),
+                crate::agent::envelope::TurnRole::Planner,
+            )
+            .await
+            .unwrap();
+        assert_eq!(reply.content, "plan");
+        assert_eq!(planner.call_count(), 1);
+        assert_eq!(root.call_count(), 0);
+
+        let reply = handle
+            .send_message(
+                ChannelSource::Socket,
+                "do it".into(),
+                None,
+                None,
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(reply.content, "root");
+        assert_eq!(root.call_count(), 1);
+        assert_eq!(planner.call_count(), 1);
     }
 
     #[tokio::test]

--- a/src/agent/envelope.rs
+++ b/src/agent/envelope.rs
@@ -100,12 +100,23 @@ pub(super) enum Envelope {
     Greeting(oneshot::Sender<String>),
 }
 
+/// Which root provider serves a turn. Channels choose per dispatch:
+/// plan turns think on the planner override, everything else on the
+/// default (spec 25 plan/execute split).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TurnRole {
+    #[default]
+    Default,
+    Planner,
+}
+
 /// Payload for a normal input turn.
 pub(super) struct InputEnvelope {
     pub source: ChannelSource,
     pub input: String,
     /// Target session override. `None` means use the active session.
     pub session_hint: Option<String>,
+    pub role: TurnRole,
     pub reply_tx: oneshot::Sender<Result<Reply, String>>,
     pub activity_tx: Option<mpsc::Sender<Activity>>,
     pub cancel: CancellationToken,

--- a/src/agent/handle.rs
+++ b/src/agent/handle.rs
@@ -23,7 +23,7 @@ use crate::workspace::Workspace;
 
 use super::PromptConfig;
 use super::actor::Agent;
-use super::envelope::{ChannelSource, Envelope, InputEnvelope};
+use super::envelope::{ChannelSource, Envelope, InputEnvelope, TurnRole};
 
 /// Cloneable handle to the agent actor.
 ///
@@ -42,6 +42,7 @@ impl AgentHandle {
     pub fn spawn<P: Provider + 'static, E: ContextEngine + 'static>(
         workspace: Arc<Workspace>,
         provider: Arc<P>,
+        planner_provider: Arc<P>,
         memory_provider: Arc<P>,
         tools: Arc<Tools>,
         distiller: Arc<Distiller>,
@@ -59,6 +60,7 @@ impl AgentHandle {
             rx,
             workspace,
             provider,
+            planner_provider,
             memory_provider,
             tools,
             distiller,
@@ -93,11 +95,35 @@ impl AgentHandle {
         activity_tx: Option<mpsc::Sender<Activity>>,
         cancel: CancellationToken,
     ) -> Result<Reply, String> {
+        self.send_message_with_role(
+            source,
+            input,
+            session_hint,
+            activity_tx,
+            cancel,
+            TurnRole::default(),
+        )
+        .await
+    }
+
+    /// [`Self::send_message`] with an explicit turn role. Channels
+    /// that distinguish phases (plan vs execute, spec 25) use this;
+    /// everything else defaults.
+    pub async fn send_message_with_role(
+        &self,
+        source: ChannelSource,
+        input: String,
+        session_hint: Option<String>,
+        activity_tx: Option<mpsc::Sender<Activity>>,
+        cancel: CancellationToken,
+        role: TurnRole,
+    ) -> Result<Reply, String> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let envelope = Envelope::Input(InputEnvelope {
             source,
             input,
             session_hint,
+            role,
             reply_tx,
             activity_tx,
             cancel,

--- a/src/channel/github/issues.rs
+++ b/src/channel/github/issues.rs
@@ -671,6 +671,17 @@ fn format_comment(view: &IssueView, author: &str, body: &str, plan_comment: Opti
         view.issue.title,
     );
     let _ = writeln!(s, "\n{body}");
+    // The plan rides the dispatch so the execution turn never depends
+    // on it surviving session compaction; the comments were fetched
+    // this tick, so the lookup is free. A plan past the 100-comment
+    // fetch cap (or deleted) degrades to the id reference below.
+    if let Some(plan) = plan_comment.and_then(|id| view.comments.iter().find(|c| c.id == id)) {
+        let _ = writeln!(
+            s,
+            "\nYour current plan (comment id {}):\n\n{}",
+            plan.id, plan.body
+        );
+    }
     let _ = writeln!(
         s,
         "\nIf this approves your plan, execute it end-to-end: create a \
@@ -1062,6 +1073,42 @@ mod tests {
         assert!(msg.contains("disagree"), "revision must license pushback");
         // The id survives into the next state while the issue is open.
         assert_eq!(next.plan_comments.get("owner/repo#1"), Some(&77));
+    }
+
+    /// The dispatch embeds the plan body when the recorded comment is
+    /// in the fetched thread, so execution never depends on the plan
+    /// surviving session compaction. An id outside the thread (fetch
+    /// cap, deletion) degrades to the id-only reference.
+    #[test]
+    fn dispatch_embeds_the_recorded_plan_body() {
+        let plan = IssueComment {
+            id: 77,
+            user: UserRef { login: BOT.into() },
+            body: "## The Plan\n1. do the thing".into(),
+            created_at: "2026-08-04T12:10:00Z".into(),
+        };
+        let mut views = [view(
+            1,
+            "2026-08-04T12:30:00Z",
+            vec![
+                plan,
+                comment("2026-08-04T12:30:00Z", "alice", "LGTM, proceed"),
+            ],
+        )];
+        let mut st = state("2026-08-04T12:00:00Z", &["owner/repo#1"]);
+        st.plan_comments.insert("owner/repo#1".into(), 77);
+
+        let (dispatches, _) = decide(&views, &st);
+        let msg = &dispatches[0].message;
+        assert!(msg.contains("Your current plan (comment id 77)"), "{msg}");
+        assert!(msg.contains("1. do the thing"), "{msg}");
+
+        // Same state, plan comment missing from the thread: id only.
+        views[0].comments.remove(0);
+        let (dispatches, _) = decide(&views, &st);
+        let msg = &dispatches[0].message;
+        assert!(!msg.contains("Your current plan"), "{msg}");
+        assert!(msg.contains("comment id 77"), "{msg}");
     }
 
     #[test]

--- a/src/channel/github/issues.rs
+++ b/src/channel/github/issues.rs
@@ -28,7 +28,7 @@ use tracing::{error, info, warn};
 
 use super::trust::Trust;
 use crate::agent::AgentHandle;
-use crate::agent::envelope::ChannelSource;
+use crate::agent::envelope::{ChannelSource, TurnRole};
 use crate::channel::execution_checkout;
 use crate::clients::github::{GithubClient, IssueComment, SearchIssue};
 use crate::config::GithubConfig;
@@ -227,7 +227,21 @@ async fn dispatch(
     // Route per-repo: all of a repo's tickets — and its PRs, which use
     // the same key — share one session.
     let body = match handle
-        .send_message(source, message, Some(d.nwo.clone()), None, cancel)
+        .send_message_with_role(
+            source,
+            message,
+            Some(d.nwo.clone()),
+            None,
+            cancel,
+            // Plan turns think on the planner override (spec 25);
+            // execution and discussion ride the default, including
+            // post-plan revision comments — a revised plan still
+            // passes the plan gate.
+            match d.kind {
+                TurnKind::Plan => TurnRole::Planner,
+                TurnKind::Discussion | TurnKind::Execution => TurnRole::Default,
+            },
+        )
         .await
     {
         Ok(reply) => {

--- a/src/channel/linear.rs
+++ b/src/channel/linear.rs
@@ -20,7 +20,7 @@ use tracing::{error, info, warn};
 
 use super::execution_checkout;
 use crate::agent::AgentHandle;
-use crate::agent::envelope::ChannelSource;
+use crate::agent::envelope::{ChannelSource, TurnRole};
 use crate::clients::linear::{Issue, LinearClient};
 use crate::error::LinearError;
 use crate::state_db::StateDb;
@@ -181,7 +181,7 @@ async fn dispatch(channel: &LinearChannel, handle: &AgentHandle, d: Dispatch) {
     // to that session for the turn, so all of a repo's tickets — and its
     // GitHub PRs, which use the same key — share one session.
     let body = match handle
-        .send_message(source, message, Some(d.repo.clone()), None, cancel)
+        .send_message_with_role(source, message, Some(d.repo.clone()), None, cancel, d.role)
         .await
     {
         Ok(reply) => {
@@ -255,6 +255,9 @@ pub struct Dispatch {
     /// True for comment turns (which may execute), false for the
     /// plan-only new-issue announcement.
     pub needs_checkout: bool,
+    /// Plan announcements think on the planner override (spec 25's
+    /// plan/execute split applies to both ticket channels alike).
+    pub role: TurnRole,
 }
 
 /// Decide what to dispatch for one poll tick.
@@ -296,6 +299,11 @@ pub fn decide_events(
                     format_new_issue_execute(issue, repo)
                 },
                 needs_checkout: !plan_first,
+                role: if plan_first {
+                    TurnRole::Planner
+                } else {
+                    TurnRole::Default
+                },
             });
             announced.insert(issue.identifier.clone());
             continue;
@@ -327,6 +335,7 @@ pub fn decide_events(
                 repo: repo.to_string(),
                 message: format_comment(issue, repo, &user.name, &user.email, &comment.body),
                 needs_checkout: true,
+                role: TurnRole::Default,
             });
         }
     }
@@ -528,6 +537,8 @@ mod tests {
         assert_eq!(dispatches[0].repo, "owner/repo");
         assert!(dispatches[0].message.contains("assigned to you"));
         assert!(!dispatches[0].needs_checkout);
+        // Plan turns think on the planner override (spec 25).
+        assert_eq!(dispatches[0].role, TurnRole::Planner);
         assert!(next.announced_issues.contains("MDK-1"));
         assert_eq!(next.last_poll, NOW);
 
@@ -548,6 +559,7 @@ mod tests {
             dispatches[0].needs_checkout,
             "direct execution needs a checkout"
         );
+        assert_eq!(dispatches[0].role, TurnRole::Default);
         let msg = &dispatches[0].message;
         assert!(msg.contains("direct execution"), "{msg}");
         assert!(msg.contains("kitaebot_mdk-1_<short-summary>"));
@@ -634,6 +646,7 @@ mod tests {
         assert_eq!(dispatches.len(), 1);
         assert_eq!(dispatches[0].repo, "owner/repo");
         assert!(dispatches[0].needs_checkout);
+        assert_eq!(dispatches[0].role, TurnRole::Default);
         let msg = &dispatches[0].message;
         assert!(msg.contains("approved, go ahead"));
         assert!(msg.contains("kitaebot_mdk-1_<short-summary>"));
@@ -853,6 +866,7 @@ mod tests {
                 repo: "owner/repo".into(),
                 message: "new issue".into(),
                 needs_checkout: false,
+                role: TurnRole::Planner,
             },
         )
         .await;
@@ -873,6 +887,7 @@ mod tests {
             repo: "owner/repo".into(),
             message: "plan".into(),
             needs_checkout: false,
+            role: TurnRole::Planner,
         };
         assert!(checkout_note(&ch, &plan).await.is_none());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -208,6 +208,11 @@ pub struct ModelOverrides {
     pub summarizer: Option<ModelSpec>,
     /// Override for memory distillation turns.
     pub memory: Option<ModelSpec>,
+    /// Override for plan turns (spec 25): plan-first announcements
+    /// think on a stronger model than the execution default. Keep it
+    /// distinct from `reviewer` — the plan gate's judge must not be
+    /// the plan's author.
+    pub planner: Option<ModelSpec>,
 }
 
 impl ModelOverrides {
@@ -216,6 +221,7 @@ impl ModelOverrides {
         [
             ("explore", &self.explore),
             ("memory", &self.memory),
+            ("planner", &self.planner),
             ("reviewer", &self.reviewer),
             ("summarizer", &self.summarizer),
             ("worker", &self.worker),

--- a/src/main.rs
+++ b/src/main.rs
@@ -435,9 +435,11 @@ fn spawn_with_engine<E: ContextEngine + 'static>(
         tools.extend_with(vec![review_log, review_disposition], &config.tools.disabled);
     }
     let memory_provider = role_provider(&provider, overrides.memory.as_ref());
+    let planner_provider = role_provider(&provider, overrides.planner.as_ref());
     agent::AgentHandle::spawn(
         workspace,
         provider,
+        planner_provider,
         memory_provider,
         Arc::new(tools),
         distiller,

--- a/src/prompts/plan-format.md
+++ b/src/prompts/plan-format.md
@@ -33,9 +33,22 @@ matter, so omit it without comment:
   couple of pieces: independently shippable pieces in dependency
   order, a `mermaid` flowchart when the graph is not a straight line,
   and a note on what is inert until the last piece lands. Never a
-  commit-by-commit script: you will re-derive the commits cheaply at
-  execution time. Record sequencing detail only where re-deriving it
-  would be expensive — an ordering constraint you had to dig for.
+  commit-by-commit script; the commits are re-derived at execution
+  time. Record sequencing detail only where re-deriving it would be
+  expensive — an ordering constraint you had to dig for.
+- **Implementation notes** — always last, addressed to the executing
+  turn, which may run on a weaker model than the one planning:
+  reviewers can stop reading above this line. Pointers and
+  constraints, never a script — a step-by-step written before
+  touching the code is wrong in detail, and scripts get followed off
+  cliffs. Name the files and seams each piece touches, the command
+  that proves each piece works, the ordering constraints you dug for,
+  and the landmines you already spotted (a lint that will fire, a
+  test that must move, a fence that must not). For each piece, state
+  the behaviors its tests must pin — observable outcomes and the edge
+  cases you already found, never test code — so the tests assert what
+  the plan intends rather than mirroring whatever the implementation
+  happens to do.
 - **Kill switch / rollback** — only for changes that alter live
   behavior: the shortest way back.
 - **Out of scope (recorded, not built)** — only when you actually

--- a/src/prompts/plan-format.md
+++ b/src/prompts/plan-format.md
@@ -17,6 +17,19 @@ Every plan has these:
   so a reviewer can spot a bad one without reading any code.
 - **Open questions** — what you need answered, each concrete enough
   to answer in a sentence. When there are none, say so in one line.
+- **Implementation notes** — always present and always the plan's
+  final section, addressed to the executing turn, which may run on a
+  weaker model than the one planning: reviewers can stop reading
+  above this line. Pointers and constraints, never a script — a
+  step-by-step written before touching the code is wrong in detail,
+  and scripts get followed off cliffs. Name the files and seams each
+  piece touches, the command that proves each piece works, the
+  ordering constraints you dug for, and the landmines you already
+  spotted (a lint that will fire, a test that must move, a fence that
+  must not). For each piece, state the behaviors its tests must pin —
+  observable outcomes and the edge cases you already found, never
+  test code — so the tests assert what the plan intends rather than
+  mirroring whatever the implementation happens to do.
 
 The rest exist only when the task earns them — an empty or
 one-obvious-sentence section is noise that buries the sections that
@@ -36,19 +49,6 @@ matter, so omit it without comment:
   commit-by-commit script; the commits are re-derived at execution
   time. Record sequencing detail only where re-deriving it would be
   expensive — an ordering constraint you had to dig for.
-- **Implementation notes** — always last, addressed to the executing
-  turn, which may run on a weaker model than the one planning:
-  reviewers can stop reading above this line. Pointers and
-  constraints, never a script — a step-by-step written before
-  touching the code is wrong in detail, and scripts get followed off
-  cliffs. Name the files and seams each piece touches, the command
-  that proves each piece works, the ordering constraints you dug for,
-  and the landmines you already spotted (a lint that will fire, a
-  test that must move, a fence that must not). For each piece, state
-  the behaviors its tests must pin — observable outcomes and the edge
-  cases you already found, never test code — so the tests assert what
-  the plan intends rather than mirroring whatever the implementation
-  happens to do.
 - **Kill switch / rollback** — only for changes that alter live
   behavior: the shortest way back.
 - **Out of scope (recorded, not built)** — only when you actually

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -33,6 +33,9 @@ pub(crate) fn workspace() -> (TempDir, Arc<Workspace>) {
 pub(crate) struct TestAgent {
     ws: Arc<Workspace>,
     provider: Arc<MockProvider>,
+    /// `None` mirrors an unset `model_overrides.planner`: the root
+    /// provider serves planner turns too.
+    planner_provider: Option<Arc<MockProvider>>,
     memory_provider: Arc<MockProvider>,
     tools: Tools,
     notifier: Option<Arc<Notifier>>,
@@ -48,11 +51,17 @@ impl TestAgent {
             memory_provider: provider.clone(),
             ws,
             provider,
+            planner_provider: None,
             tools: Tools::default(),
             notifier: None,
             max_iterations: 1,
             duty_trigger: None,
         }
+    }
+
+    pub(crate) fn planner(mut self, provider: Arc<MockProvider>) -> Self {
+        self.planner_provider = Some(provider);
+        self
     }
 
     pub(crate) fn tools(mut self, tools: Tools) -> Self {
@@ -89,9 +98,13 @@ impl TestAgent {
             1,
             8192,
         ));
+        let planner = self
+            .planner_provider
+            .unwrap_or_else(|| self.provider.clone());
         AgentHandle::spawn(
             self.ws,
             self.provider,
+            planner,
             self.memory_provider,
             Arc::new(self.tools),
             distiller,


### PR DESCRIPTION
Closes #105.

The plan-first choreography already separates thinking from doing — plan turn, human gate, execution turn — but both phases ran on one root model, so the implementation bulk paid strong-model rates for work a gate-reviewed plan mostly de-risks. This splits them: plan turns think on a new `model_overrides.planner`, everything else rides the default, and the deploy config drops the default to `z-ai/glm-5.3-flash` with `glm-5.3` as the planner.

Five commits:

1. **Route plan turns to a planner model override** — `TurnRole` on the envelope, `send_message_with_role`, per-envelope provider selection in the actor with the ledger stamping the model that actually ran (so `/usage` separates the phases for the executor evaluation with no new columns), GitHub issues mapping `TurnKind::Plan` to it. Post-plan comment turns — revisions included — deliberately ride the default: the channel cannot tell approval from feedback pre-dispatch, and a revised plan still passes the plan gate.
2. **Embed the recorded plan in post-plan dispatches** — the execution turn must see the gate-reviewed plan text unconditionally. Session history is not relied on: post-compaction the assembled prompt holds a summary (LCM keeps the bytes but recovery is a tool round the model must initiate; flat is lossy outright). The lookup is pure — the comments were fetched this tick. This also removed the plan-pinning seam with #101.
3. **Executor-facing "Implementation notes" in the plan format** — the review brief now ends with a section addressed to the executing turn: files and seams per piece, verify commands, behaviors its tests must pin (so tests assert intent, not mirror implementation), ordering constraints, landmines. Pointers and constraints, never a script. Reviewers stop reading above the line; the plan gate reviews it with the rest.
4. **The deploy model split** — flash default, glm-5.3 planner (not kimi: the plan gate's judge must not be the author), plus the audit's one hard finding: `memory.model` pinned to glm-5.3, since distillation had only a reasoning bound and would otherwise inherit flash+low for facts that inject into every future turn. Duties, chat, and PR turns were audited and left on flash deliberately — their quality surfaces where a human sees it.
5. **Linear parity** — Linear's plan-first announcements also dispatch with the planner role; without this the flip would have silently degraded Linear planning to flash.

Rollout: everything is inert until the rebuild; rollback is one config line. The ledger's per-turn model stamp gives the flash-vs-glm-5.3 outcome and cost comparison on execution turns — that data decides whether the flash default survives.
