### PR TITLE
Grant the daemon ruleset read access to /lib64

### DIFF
--- a/specs/15-sandbox.md
+++ b/specs/15-sandbox.md
@@ -122,7 +122,8 @@ commands (exec tier), and every `GitCli` call including hooks (git
 tier). Fixed-argv, hook-free git calls (origin lookup, current-branch)
 stay unconfined by design — they run no repo code. **Not yet covered:**
 direnv flake-devshell evaluation still runs under the daemon's
-inherited grant; confining it needs the tier threaded through
+inherited grant (now including `/lib64`, which foreign devshell hooks'
+build tooling scandirs); confining it needs the tier threaded through
 `DirenvCache`, a planned follow-up.
 
 ### Architecture
@@ -152,6 +153,7 @@ The per-child tiers are tabulated under Per-child confinement above.
 | `/nix/store` | Read + execute | Optional |
 | `/tmp` | Read, write, mkdir, symlink, unlink, execute, truncate. No `MakeChar`, `MakeBlock`, `MakeSock`, `MakeFifo`. | Optional |
 | `/etc` | `ReadFile`, `ReadDir` | Optional |
+| `/lib64` | `ReadFile`, `ReadDir` | Optional |
 | `/run` | `ReadFile`, `ReadDir` | Optional |
 | `/dev` | `ReadFile`, `ReadDir`, `WriteFile` | Optional |
 | `/proc` | `ReadFile`, `ReadDir` | Optional |

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -161,6 +161,12 @@ impl Policy {
                 rationale: "System config — read-only (resolv.conf, CA certs)",
             },
             Rule {
+                path: PathBuf::from("/lib64"),
+                access: read_files,
+                presence: Presence::Optional,
+                rationale: "Loader dir — direnv evaluates foreign devshell hooks whose build tooling scandirs it (prisma postinstall)",
+            },
+            Rule {
                 path: PathBuf::from("/run"),
                 access: read_files,
                 presence: Presence::Optional,
@@ -668,6 +674,20 @@ mod tests {
     }
 
     #[test]
+    fn lib64_is_read_only_no_execute() {
+        // Foreign devshell hooks (prisma postinstall) scandir /lib64;
+        // the direnv subprocess inherits this ruleset (confine: None).
+        let policy = test_policy();
+        let rule = policy
+            .rules()
+            .iter()
+            .find(|r| r.path == Path::new("/lib64"))
+            .expect("/lib64 rule must exist");
+        assert_eq!(rule.access, AccessFs::ReadFile | AccessFs::ReadDir);
+        assert!(!rule.access.contains(AccessFs::Execute));
+    }
+
+    #[test]
     fn socket_dir_derived_from_path() {
         let policy = Policy::new(
             Path::new("/workspace"),
@@ -712,9 +732,9 @@ mod tests {
     #[test]
     fn expected_rule_count() {
         let policy = test_policy();
-        // workspace, /nix/store, /tmp, /etc, /run, /dev, /proc,
+        // workspace, /nix/store, /tmp, /etc, /lib64, /run, /dev, /proc,
         // /sys/fs/cgroup, socket_dir
-        assert_eq!(policy.rules().len(), 9);
+        assert_eq!(policy.rules().len(), 10);
     }
 
     #[test]


### PR DESCRIPTION
Closes #124.

One rule: `Policy::new` (the daemon's own Landlock ruleset, applied at startup and inherited by `confine: None` children) gains the read-only `/lib64` rule that `child_exec`/`child_git` and the bwrap wrapper already carry — `ReadFile | ReadDir`, `Presence::Optional`, no execute. The direnv evaluation subprocess is the one spawn path that runs with no tighter per-child tier, so foreign devshell hooks it evaluates (lightning-node's flake `.#agent`, whose `pnpm-install` runs prisma postinstall scandir'ing `/lib64`) hit EACCES and the whole devshell fails. This fixes exactly that hole and nothing else.

- Test: `lib64_is_read_only_no_execute` mirrors the child-tier test; `expected_rule_count` 9 → 10.
- Spec 15: daemon-policy table gains the `/lib64` row; the direnv "Not yet covered" note now names the path.

Validation: all 28 `sandbox::tests` pass; full `nix flake check` gate green at commit time (cargo-deny duplicate-crate warnings pre-existing). Live verification against the real lightning-node flake on the deployed VM still needs a daemon redeploy — the running daemon carries the old ruleset until then.

Post-merge checklist (the issue's second half — runtime-workspace files a repo branch cannot carry):
- [x] Redeploy the daemon so the new ruleset is live.
- [x] Re-test `direnv export json` against `projects/CumuloGlobal/lightning-node`: prisma's postinstall must no longer EACCES on `/lib64`.
- [x] Update `memory/topics/tooling.md` "Devshell / direnv on lightning-node": remove the prisma `/lib64` failure mode (keep the Playwright mismatch and nixpkgs deprecation warnings if still true), and record the resolved devshell state.
- [x] Delete the `memory/MEMORY.md` index line "Daemon's own ruleset lacks /lib64 (#72 residual)".
