### PR TITLE
Block issue-comment writes through github_api

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -453,7 +453,7 @@ directory, never a repo.
 
 | Tool | Description |
 |------|-------------|
-| `github_api` | Generic REST escape hatch. Paths are forced under `repos/<owner>/<repo>/` and the first segment must be one of `actions` (GET only — writing dispatches, re-runs, or cancels workflows, a human decision), `dependabot` (GET only — writing dismisses alerts, a human decision), `issues`, `labels`, `milestones`, `pulls`, `releases`. |
+| `github_api` | Generic REST escape hatch. Paths are forced under `repos/<owner>/<repo>/` and the first segment must be one of `actions` (GET only — writing dispatches, re-runs, or cancels workflows, a human decision), `dependabot` (GET only — writing dismisses alerts, a human decision), `issues` (comment paths GET only — the channels post the turn's reply as the thread comment, and a tool-written comment duplicates it and steals the plan anchor, spec 25), `labels`, `milestones`, `pulls`, `releases`. |
 | `github_ci_status` | Report the latest CI run on a branch (pending, green, or red), with failure logs when it failed. |
 | `github_pr_create` | Create a pull request. |
 | `github_pr_list` | List pull requests (open/closed/all). |

--- a/src/prompts/plan-format.md
+++ b/src/prompts/plan-format.md
@@ -1,7 +1,9 @@
 Analyze the task and reply with a review-ready plan brief in markdown,
 written so a human can assess it in one read. Your reply is
 posted verbatim as a comment on the ticket — start directly with the
-plan: no preamble, no narration.
+plan: no preamble, no narration. Never post the plan to the ticket
+yourself; replying is the posting, and a tool-posted copy duplicates
+the thread.
 
 Every plan has these:
 

--- a/src/prompts/review-gates.md
+++ b/src/prompts/review-gates.md
@@ -27,7 +27,9 @@ so the size of the change is not your problem and there is nothing to
 shrink.
 
 - **Plan gate** (gate "plan", git_ref: branch) — after writing the
-  plan, before posting it for sign-off or starting to implement. Pack
+  plan, before delivering it for sign-off or starting to implement.
+  Delivering means ending your turn with the plan as your reply — the
+  channel posts it to the thread; never post it through a tool. Pack
   the task statement, the plan, and the repo conventions you were
   given. A plan has no diff; it is packed by value as before.
 - **Commit gate** (gate "commit", git_ref: current HEAD SHA) — after

--- a/src/tools/github/api.rs
+++ b/src/tools/github/api.rs
@@ -58,8 +58,9 @@ struct Args {
     method: Method,
     /// Path under `repos/<owner>/<repo>/`, e.g. `issues/42/comments`
     /// or `pulls?state=open`. Must start with one of: actions (GET
-    /// only), dependabot (GET only), issues, labels, milestones,
-    /// pulls, releases.
+    /// only), dependabot (GET only), issues (comment paths GET only —
+    /// the channel posts your final reply as the thread comment),
+    /// labels, milestones, pulls, releases.
     path: String,
     /// JSON body for POST/PATCH.
     #[serde(default, deserialize_with = "string_or_value")]

--- a/src/tools/github/api.rs
+++ b/src/tools/github/api.rs
@@ -113,6 +113,20 @@ fn validate_path(path: &str, method: Method) -> Result<(), ToolError> {
             guidance: format!("{resource} is read-only through this tool: use GET"),
         });
     }
+    // Covers `issues/{n}/comments` and `issues/comments/{id}`. The
+    // channels post the turn's reply as the comment; a comment written
+    // here duplicates it and steals the plan anchor (issue #116).
+    if resource == "issues"
+        && !matches!(method, Method::Get)
+        && path.split(['/', '?']).any(|segment| segment == "comments")
+    {
+        return Err(ToolError::Blocked {
+            operation: format!("github_api {} {path}", method.as_str()),
+            guidance: "issue comments are read-only through this tool: your final \
+                       reply is posted to the thread by the channel"
+                .into(),
+        });
+    }
     // '%' is blocked wholesale: percent-encoding can smuggle a '/'
     // past the segment check, and none of the allowed resources
     // need it.
@@ -220,13 +234,35 @@ mod tests {
         }
     }
 
+    /// Writing a comment duplicates the channel's reply posting and
+    /// steals the plan anchor (#116); reading stays open, and label
+    /// writes on the same resource are untouched.
+    #[test]
+    fn issue_comment_writes_are_blocked() {
+        for path in [
+            "issues/42/comments",
+            "issues/comments/123",
+            "issues/42/comments?x=1",
+        ] {
+            for method in [Method::Delete, Method::Patch, Method::Post] {
+                assert!(
+                    matches!(validate_path(path, method), Err(ToolError::Blocked { .. })),
+                    "{} should be blocked on {path}",
+                    method.as_str(),
+                );
+            }
+            assert!(validate_path(path, Method::Get).is_ok(), "GET {path}");
+        }
+        assert!(validate_path("issues/42/labels", Method::Post).is_ok());
+    }
+
     #[tokio::test]
     async fn prefixes_the_origin_repo() {
         let api = stub_api_with_repo("owner/repo", |method, path, body| {
             assert_eq!(method, "POST");
-            assert_eq!(path, "repos/owner/repo/issues/42/comments");
+            assert_eq!(path, "repos/owner/repo/issues/42/labels");
             let payload: serde_json::Value = serde_json::from_slice(&body.unwrap()).unwrap();
-            assert_eq!(payload["body"], "done");
+            assert_eq!(payload["labels"][0], "bug");
             br#"{"id":1}"#.to_vec()
         });
         let tool = Api(api);
@@ -234,8 +270,8 @@ mod tests {
             .run(&Args {
                 repo_dir: "projects/r".into(),
                 method: Method::Post,
-                path: "issues/42/comments".into(),
-                body: Some(serde_json::json!({"body": "done"})),
+                path: "issues/42/labels".into(),
+                body: Some(serde_json::json!({"labels": ["bug"]})),
             })
             .await
             .unwrap();
@@ -250,7 +286,7 @@ mod tests {
             // The raw bytes must be a JSON object, not a JSON string.
             assert_eq!(raw[0], b'{', "body must start with '{{', got: {raw:?}");
             let payload: serde_json::Value = serde_json::from_slice(&raw).unwrap();
-            assert_eq!(payload["body"], "done");
+            assert_eq!(payload["labels"][0], "bug");
             br#"{"id":1}"#.to_vec()
         });
         let tool = Api(api);
@@ -258,8 +294,8 @@ mod tests {
         let args: Args = serde_json::from_value(serde_json::json!({
             "repo_dir": "projects/r",
             "method": "POST",
-            "path": "issues/42/comments",
-            "body": "{\"body\": \"done\"}"
+            "path": "issues/42/labels",
+            "body": "{\"labels\": [\"bug\"]}"
         }))
         .unwrap();
         let out = tool.run(&args).await.unwrap();
@@ -273,15 +309,15 @@ mod tests {
             let raw = body.unwrap();
             assert_eq!(raw[0], b'{', "body must start with '{{', got: {raw:?}");
             let payload: serde_json::Value = serde_json::from_slice(&raw).unwrap();
-            assert_eq!(payload["body"], "done");
+            assert_eq!(payload["labels"][0], "bug");
             br#"{"id":1}"#.to_vec()
         });
         let tool = Api(api);
         let args: Args = serde_json::from_value(serde_json::json!({
             "repo_dir": "projects/r",
             "method": "POST",
-            "path": "issues/42/comments",
-            "body": {"body": "done"}
+            "path": "issues/42/labels",
+            "body": {"labels": ["bug"]}
         }))
         .unwrap();
         let out = tool.run(&args).await.unwrap();


### PR DESCRIPTION
Closes #116.

On #114 the plan turn posted its plan through `github_api POST issues/114/comments` mid-turn, then replied with a recap — so the thread got the plan twice, and `plan_comments` anchored the issue to the recap instead of the plan. The write was reachable because only `actions` and `dependabot` are read-only resources, and nothing in the codebase legitimately writes issue comments through the escape hatch: the channels post replies, diff replies and comment edits have dedicated tools.

Two commits, suspenders then belt:

1. **Block issue-comment writes through `github_api`** — non-GET on `issues` paths containing a `comments` segment is refused (covers `issues/{n}/comments` and `issues/comments/{id}`); label writes and all GETs untouched. The guidance string tells the model where its comment actually goes, so the refusal teaches instead of just blocking.
2. **Make the prompts say the reply is the posting** — `review-gates.md`'s "before posting it for sign-off" framed posting as an action the model performs, which is the instruction that invited the tool write; it now says delivering the plan means ending the turn with it as the reply. `plan-format.md` states the same rule from the channel's side.

The #114 state itself was repaired at the time (plan anchor repointed to the real plan comment); this makes the recurrence structurally impossible.
