### PR TITLE
Redraw empty provider responses

### DIFF
--- a/specs/02-provider.md
+++ b/specs/02-provider.md
@@ -84,14 +84,20 @@ All backends use the same wire format. Switching backend requires only changing
 Transport failures (connection, timeout, reading the body) map to `Network`.
 `ProviderError::is_transient()` classifies retryability: `Network`,
 `ServerError`, and `RateLimited` may succeed if the identical request is
-resent; everything else is a defect in the request or credentials and must
-never be retried.
+resent; `MalformedToolCall` and `EmptyResponse` are bad draws, not bad
+requests — generation is not deterministic, and a fresh draw is the
+remedy. Everything else is a defect in the request or credentials and
+must never be retried.
 
 ### Retry
 
 `CompletionsProvider::chat` retries transient errors up to 3 times with
-exponential backoff: 1s/2s/4s, or 5s/10s/20s when rate limited. Constants,
-not config. Fatal errors return immediately. Each retry logs a warning.
+exponential backoff: 1s/2s/4s, or 5s/10s/20s when rate limited; empty
+responses get a tighter budget of 2 retries, so a provider that burns a
+minute per empty draw still fails through in bounded time while a
+sub-agent's built-up context survives the common one-off glitch (#120).
+Constants, not config. Fatal errors return immediately. Each retry logs
+a warning.
 
 The loop itself is a generic combinator (`retry::retry(op, policy)`,
 reusable by other IO layers); the provider owns only the pure policy
@@ -149,14 +155,15 @@ The provider is split into two layers:
 | Malformed response (valid HTTP, bad JSON) | `ProviderError::InvalidResponse` |
 | Empty choices array | `ProviderError::InvalidResponse` |
 | No content, no tool calls, `finish_reason = "length"` | `ProviderError::Truncated` — generation hit `provider.max_tokens` before any output (reasoning models can burn the whole budget on reasoning); the fix is a `reasoning` bound or a larger `provider.max_tokens` |
-| No content, no tool calls, other finish reason | `ProviderError::EmptyResponse` |
+| No content, no tool calls, other finish reason | `ProviderError::EmptyResponse` — redrawn inside the retry unit (see Retry) |
 | Partial text, `finish_reason = "length"` | Surfaced as a normal reply with `[truncated at max_tokens]` appended, so readers and the model (next turn) see the cut |
 | Transport failure (connect, timeout, body read) | `ProviderError::Network` |
 | HTTP 5xx | `ProviderError::ServerError` with status and body |
 | HTTP 4xx (other than 401/403/429) | `ProviderError::BadRequest` with status and body |
 
-Transient failures (`Network`, `ServerError`, `RateLimited`) are retried
-inside the provider (see Retry). Once retries are exhausted, and for all
+Transient failures (`Network`, `ServerError`, `RateLimited`,
+`MalformedToolCall`, `EmptyResponse`) are retried inside the provider
+(see Retry). Once retries are exhausted, and for all
 other failures, the agent loop surfaces the error to the user and saves
 the session.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -153,7 +153,8 @@ impl ProviderError {
     pub fn is_transient(&self) -> bool {
         matches!(
             self,
-            Self::MalformedToolCall { .. }
+            Self::EmptyResponse
+                | Self::MalformedToolCall { .. }
                 | Self::Network(_)
                 | Self::RateLimited
                 | Self::ServerError(_)

--- a/src/provider/completions.rs
+++ b/src/provider/completions.rs
@@ -20,12 +20,22 @@ use super::{CallUsage, ChatOutcome, Provider};
 /// Retries after the initial attempt for transient failures.
 const MAX_RETRIES: u32 = 3;
 
+/// Empty responses get a tighter budget: a wedged provider that burns
+/// a minute per empty draw must fail through in bounded time (the
+/// half of 532e000's fail-fast rationale that still holds).
+const EMPTY_RETRIES: u32 = 2;
+
 /// Retry policy for chat requests: exponential backoff for transient
 /// errors, starting at 1s, or 5s when rate limited (the window is
 /// typically seconds, not milliseconds). No jitter: one daemon, no
 /// thundering herd.
 fn retry_policy(e: &ProviderError, attempt: u32) -> Option<Duration> {
-    if !e.is_transient() || attempt >= MAX_RETRIES {
+    let max = if matches!(e, ProviderError::EmptyResponse) {
+        EMPTY_RETRIES
+    } else {
+        MAX_RETRIES
+    };
+    if !e.is_transient() || attempt >= max {
         return None;
     }
     let base = if matches!(e, ProviderError::RateLimited) {
@@ -626,6 +636,37 @@ mod tests {
         )
     }
 
+    /// An empty draw is redrawn, not surfaced: parsing lives inside
+    /// the retry unit precisely so a bad draw costs one request, not a
+    /// sub-agent's whole context (#120).
+    #[tokio::test(start_paused = true)]
+    async fn chat_redraws_empty_responses() {
+        use std::sync::atomic::Ordering;
+        let (provider, calls) = faulty_body_provider(1, EMPTY_CONTENT_BODY);
+        let outcome = provider.chat("s", &[], &[]).await.unwrap();
+        assert!(matches!(outcome.response, Response::Text(t) if t == "hi"));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// A provider that only produces empty draws fails through on the
+    /// tighter empty budget, not the full retry budget.
+    #[tokio::test(start_paused = true)]
+    async fn chat_bounds_empty_redraws() {
+        use std::sync::atomic::Ordering;
+        let (provider, calls) = faulty_body_provider(usize::MAX, EMPTY_CONTENT_BODY);
+        let err = provider.chat("s", &[], &[]).await.unwrap_err();
+        assert!(matches!(err, ProviderError::EmptyResponse));
+        assert_eq!(calls.load(Ordering::SeqCst), 1 + EMPTY_RETRIES as usize);
+    }
+
+    #[test]
+    fn policy_empty_response_capped_below_max_retries() {
+        let e = ProviderError::EmptyResponse;
+        assert_eq!(retry_policy(&e, 0), Some(Duration::from_secs(1)));
+        assert_eq!(retry_policy(&e, 1), Some(Duration::from_secs(2)));
+        assert_eq!(retry_policy(&e, EMPTY_RETRIES), None);
+    }
+
     #[tokio::test(start_paused = true)]
     async fn chat_retries_transient_errors_until_success() {
         use std::sync::atomic::Ordering;
@@ -658,6 +699,10 @@ mod tests {
 
     /// A 200 with nothing in it.
     const EMPTY_CONTENT_BODY: &str = r#"{"choices":[{"message":{"content":""}}]}"#;
+
+    /// A 200 whose generation hit `max_tokens` before any output.
+    const TRUNCATED_BODY: &str =
+        r#"{"choices":[{"message":{"content":""},"finish_reason":"length"}]}"#;
 
     /// Provider whose client answers 200 with `faulty` for the first
     /// `failures` calls and a usable text response after, counting
@@ -722,13 +767,15 @@ mod tests {
     }
 
     /// Parsing moved inside the retry unit; that must not make every
-    /// parse failure retryable. Only the policy decides.
+    /// parse failure retryable. Only the policy decides: truncation is
+    /// structural (the same request starves the same way), so it is
+    /// never redrawn.
     #[tokio::test(start_paused = true)]
-    async fn chat_does_not_redraw_an_empty_response() {
+    async fn chat_does_not_redraw_a_truncated_response() {
         use std::sync::atomic::Ordering;
-        let (provider, calls) = faulty_body_provider(usize::MAX, EMPTY_CONTENT_BODY);
+        let (provider, calls) = faulty_body_provider(usize::MAX, TRUNCATED_BODY);
         let err = provider.chat("s", &[], &[]).await.unwrap_err();
-        assert!(matches!(err, ProviderError::EmptyResponse));
+        assert!(matches!(err, ProviderError::Truncated));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 


### PR DESCRIPTION
Closes #120.

Three explore sub-agents died identically in one duty turn: a 200 with empty content and `finish_reason: "stop"`, terminal for the sub-agent, minutes of built-up context discarded, the parent respawning from zero into the same wall.

`EmptyResponse` becomes transient — same failure class as `MalformedToolCall`, whose rationale already sits in the code: the request is fine, the draw was not, and a fresh draw is the remedy. Because retry lives in the provider, every consumer gets the redraw for free; for sub-agents it turns a from-zero respawn (the most expensive possible retry) into one request against an already-built context.

The original fence (532e000: no retry, "failing fast and letting the caller resend beats doubling the wait") is honored where it still holds: empties get their own tighter cap of 2 retries below the general 3, so a provider genuinely wedged into minute-long empty draws fails through in bounded time. `Truncated` stays non-transient — max_tokens starvation is structural, the same request starves the same way — and the old fence test now pins exactly that.

Also fixes pre-existing spec drift found while updating spec 02: `MalformedToolCall` was already transient in code but missing from the spec's transience list.

Out of scope, per the issue's own text: the blocked `web_fetch` that preceded each death (explore scope vs `github_*` tools) is an observation, not this bug.
