### PR TITLE
Accept in-workspace absolute paths; make the diffs convention visible

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -99,7 +99,12 @@ hardcoded, so typos are caught by tests instead.
   by `job_logs` (CI logs); `github_api`'s raw path uses head-keeping
   `truncate_output` (generic API responses are not tail-weighted).
 - **`PathGuard`** — workspace-confined path resolution. Rejects null bytes,
-  `../`, and absolute paths. Canonicalizes and verifies the result is under the
+  `../`, and absolute paths outside the workspace; an absolute path under
+  the root is accepted as the relative spelling it names (the prompt
+  advertises the root, so models echo it — refusing the unambiguous form
+  only burned iterations). Normalization happens before the daemon-owned
+  write fence, which compares components and must never see the absolute
+  spelling. Canonicalizes and verifies the result is under the
   workspace root. Provides `resolve()` for existing files and `resolve_new()`
   for files that don't exist yet; the `resolve_writable*` variants add the
   daemon-owned fence: `config.toml`, `context/`, and `state/` are readable but

--- a/specs/05-workspace.md
+++ b/specs/05-workspace.md
@@ -48,7 +48,7 @@ Backup and restore ([spec 09](09-vm.md)) turns on this split:
 
 | Durable | Derived |
 |---------|---------|
-| `context/` — whatever the engine keeps there | `projects/`, `reviews/`, `.diffs/` — re-cloned or regenerated |
+| `context/` — whatever the engine keeps there | `projects/`, `reviews/`, `diffs/` — re-cloned or regenerated |
 | `state/` — `kitaebot.db`, the `.md` logs | build caches (`.cargo`, `.npm`, `.cache`, `.local`) |
 | `memory/` | |
 | | Nix-provisioned symlinks (`SOUL.md`, `AGENTS.md`, `USER.md`, `config.toml`) |

--- a/specs/15-sandbox.md
+++ b/specs/15-sandbox.md
@@ -63,7 +63,8 @@ The `exec` tier (`Policy::child_exec`):
 | Path | Access | Effect |
 |------|--------|--------|
 | Workspace root | list only (`ReadDir`) | Navigation works. Landlock rules are recursive, so `ReadFile` here would grant reads of everything beneath; with list-only, file reads and all writes under `state/`, `context/`, `memory/`, and `config.toml` are denied, and new root-level files cannot be created |
-| `projects/` | full | Builds, checkouts, `diffs/` all work |
+| `projects/` | full | Builds and checkouts work |
+| `diffs/` | full | Packed review diffs (spec 20): exec redirects write here. Pre-created by workspace init — the root is list-only for exec children, so only the daemon can create it, and Landlock cannot grant a missing path |
 | `state/review-checklist.md` | read | The one model-facing state file |
 | `context/lcm/payloads/` | read | The LCM payload store: `<file>` references hand these workspace-relative paths to the model ([spec 14](14-context-engine.md)), so shell reads of them must work. Optional — created lazily on first externalization, and references only exist after that point |
 | `.cache`, `.cargo`, `.npm`, `.local/{share,state}/pnpm` | full | `HOME` is the workspace root on the VM; nix flake eval fails hard without `~/.cache/nix`, and cargo/npm/pnpm need their caches. Provisioned by tmpfiles — Landlock cannot grant a path that does not exist. Grants are named, never speculative: onboarding a repo whose toolchain caches outside XDG (`.m2`, `.gradle`, `~/go/pkg/mod`, …) means adding its rule in `Policy::child_exec` plus a tmpfiles entry in the same commit |

--- a/specs/15-sandbox.md
+++ b/specs/15-sandbox.md
@@ -63,7 +63,7 @@ The `exec` tier (`Policy::child_exec`):
 | Path | Access | Effect |
 |------|--------|--------|
 | Workspace root | list only (`ReadDir`) | Navigation works. Landlock rules are recursive, so `ReadFile` here would grant reads of everything beneath; with list-only, file reads and all writes under `state/`, `context/`, `memory/`, and `config.toml` are denied, and new root-level files cannot be created |
-| `projects/` | full | Builds, checkouts, `.diffs/` all work |
+| `projects/` | full | Builds, checkouts, `diffs/` all work |
 | `state/review-checklist.md` | read | The one model-facing state file |
 | `context/lcm/payloads/` | read | The LCM payload store: `<file>` references hand these workspace-relative paths to the model ([spec 14](14-context-engine.md)), so shell reads of them must work. Optional — created lazily on first externalization, and references only exist after that point |
 | `.cache`, `.cargo`, `.npm`, `.local/{share,state}/pnpm` | full | `HOME` is the workspace root on the VM; nix flake eval fails hard without `~/.cache/nix`, and cargo/npm/pnpm need their caches. Provisioned by tmpfiles — Landlock cannot grant a path that does not exist. Grants are named, never speculative: onboarding a repo whose toolchain caches outside XDG (`.m2`, `.gradle`, `~/go/pkg/mod`, …) means adding its rule in `Policy::child_exec` plus a tmpfiles entry in the same commit |

--- a/specs/20-github.md
+++ b/specs/20-github.md
@@ -173,11 +173,17 @@ have them:
   adjacency: the separate clone kept PR content in a directory the
   working tree could not reach.
 
-Diffs packed by reference go to `.diffs/` at the workspace root, not
+Diffs packed by reference go to `diffs/` at the workspace root, not
 under `reviews/`. They are not review-specific — spec 23's open question
 has the self gates packing the same way — and `reviews/` now holds
 worktrees of other repositories, which is the wrong parent for a scratch
-directory.
+directory. The directory is deliberately not hidden: the layout is
+model-facing, models learn it from `ls`, and the dotted original
+(`.diffs/`) was invisible enough that turns re-derived their own
+locations (`projects/` dumps, an invented `.diff/run.sh`) instead of
+finding the convention. Workspace root, outside every checkout, is the
+load-bearing part — a diff written inside a repo dirties the tree
+about to be committed from.
 
 Both the review-request and tracked passes prepare the checkout this
 way. Preparation failure logs a warning and skips the PR for the tick
@@ -303,7 +309,7 @@ available, rather than in a root turn holding outward-facing tools.
   Review checkout). Read-only: git only to read; never a checkout
   over it. The working checkout under `projects/` is not involved.
 - The root produces the diff by redirecting
-  `git diff origin/<base>...HEAD` to a file under `.diffs/`,
+  `git diff origin/<base>...HEAD` to a file under `diffs/`,
   and packs its **path** into the reviewer dispatch together with the
   PR's stated intent (title, body, commit messages), the checkout
   root, and review metadata `{repo, gate: "pr", git_ref: <head SHA>}`
@@ -359,7 +365,7 @@ disposition), and instructs the model to:
 - Produce the incremental diff, not the whole PR: the channel has
   already prepared the review checkout (same as the initial review —
   new head detached, read-only), so `git diff {prev}...HEAD` in it, to
-  the same `.diffs/` path convention. Three dots: after a force
+  the same `diffs/` path convention. Three dots: after a force
   push `{prev}` is no longer an ancestor, and diffing from the merge
   base degrades better than diffing against a diverged tip. Falls back
   to the full `gh pr diff` when that fails anyway.

--- a/specs/23-self-review.md
+++ b/specs/23-self-review.md
@@ -142,7 +142,7 @@ class of mistake — a wrong approach found at commit 5 costs a branch,
 found at the plan it costs one call.
 
 **2. Commit review** — after staging, before every `git_commit`. The
-parent redirects the staged diff to a file under `.diffs/` at the
+parent redirects the staged diff to a file under `diffs/` at the
 workspace root (never inside the repo, which would dirty the tree
 about to be committed from) and packs the path plus the proposed
 commit message; the reviewer reads the diff with `file_read`. The
@@ -152,7 +152,7 @@ staged diff before committing — history never contains the mistake and
 no amend is needed.
 
 **3. Series review** — before `git_push` of a branch that will become a
-PR. The parent writes the branch diff against the base to `.diffs/`
+PR. The parent writes the branch diff against the base to `diffs/`
 the same way and packs the path plus the commit list (subjects). The
 reviewer checks what per-commit review cannot see: does the sum solve
 the task; dead ends left behind (commit 4 quietly reverting half of

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -30,6 +30,9 @@ const DERIVED: &[&str] = &[
     // Checkouts and their artifacts — re-cloned or regenerated.
     "projects",
     "reviews",
+    crate::workspace::DIFFS_DIR,
+    // Legacy spelling; deployed workspaces keep it until the hygiene
+    // sweep exists.
     ".diffs",
     // Nix-provisioned symlinks.
     crate::workspace::CONFIG_FILE,

--- a/src/channel/github/prs.rs
+++ b/src/channel/github/prs.rs
@@ -1644,7 +1644,7 @@ mod tests {
             "reviewer call fails",
             // The diff is packed by reference, and pr-gate findings
             // are dispositioned on the follow-up turn, not at submit.
-            ".diffs/pr-",
+            "diffs/pr-",
             "Do not read the diff yourself",
             // Conventions come from the base, not the PR head.
             "origin/<base>:AGENTS.md",

--- a/src/prompts/review-gates.md
+++ b/src/prompts/review-gates.md
@@ -10,7 +10,7 @@ in-context: the reviewer sees the artifact cold, which is the point.
 
 The reviewer does not read repo conventions for itself, so hand them
 over: `git -C projects/<owner>/<repo> show origin/HEAD:AGENTS.md >
-.diffs/conventions.md`, and name the path in the prompt. From
+diffs/conventions.md`, and name the path in the prompt. From
 `origin/HEAD` rather than the working tree, because if your own change
 edits the conventions then the working copy is part of the artifact,
 and an artifact does not get to state the rules it is judged by.
@@ -19,7 +19,7 @@ none. A single line naming another file means `AGENTS.md` is a symlink
 and git gave you the link target — write the file it names.
 
 Diffs are packed by reference, exactly as PR reviews pack them: write
-the diff to a file under `.diffs/` at the workspace root — never
+the diff to a file under `diffs/` at the workspace root — never
 inside the repo, which would dirty the tree you are about to commit
 from — pack the path, and tell the reviewer to read it with
 `file_read`. The redirect means no diff text comes back through exec,
@@ -33,13 +33,13 @@ shrink.
 - **Commit gate** (gate "commit", git_ref: current HEAD SHA) — after
   staging, before every git_commit. Write the staged diff out:
   `git -C projects/<owner>/<repo> diff --cached >
-  .diffs/commit-<HEAD SHA>.diff`. Pack the path and the proposed
+  diffs/commit-<HEAD SHA>.diff`. Pack the path and the proposed
   commit message. Fix must-fix findings in the staged diff, then
   commit: history never contains the mistake.
 - **Series gate** (gate "series", git_ref: branch head SHA) — before
   pushing a branch that will become a pull request. Write the branch
   diff out: `git -C projects/<owner>/<repo> diff origin/<base>...HEAD >
-  .diffs/series-<head SHA>.diff`. Pack the path and the commit list
+  diffs/series-<head SHA>.diff`. Pack the path and the commit list
   (subjects). This catches what per-commit review cannot: dead ends,
   naming drift, a sum that does not solve the task.
 

--- a/src/prompts/review-protocol.md
+++ b/src/prompts/review-protocol.md
@@ -33,13 +33,13 @@ judge per review.
 
 - Write the whole diff to a file instead of reading it into your
   context. With `working_dir` at the workspace root:
-  `mkdir -p .diffs && git -C reviews/<owner>/<repo> diff
-  origin/<base>...HEAD > .diffs/pr-<n>-<head SHA>.diff`.
+  `mkdir -p diffs && git -C reviews/<owner>/<repo> diff
+  origin/<base>...HEAD > diffs/pr-<n>-<head SHA>.diff`.
   The redirect means no diff text comes back through exec, so the size
   of the PR is not your problem and there is nothing to shrink.
 - Write the base branch's conventions out too:
   `git -C reviews/<owner>/<repo> show origin/<base>:AGENTS.md >
-  .diffs/conventions-<n>.md`. From the base, never from HEAD: the
+  diffs/conventions-<n>.md`. From the base, never from HEAD: the
   conventions a PR is judged against are the ones already agreed, not
   the ones it proposes. `AGENTS.md` is the only name to look up; if the
   repo has none, skip this and say so in the dispatch. If the output is
@@ -114,7 +114,7 @@ review the delta, not the whole PR:
 
 - Write the delta to a file the same way, with the SHAs from the
   dispatch: `git -C reviews/<owner>/<repo> diff <prev>...HEAD >
-  .diffs/pr-<n>-<head SHA>.diff`. Three dots, so a force push
+  diffs/pr-<n>-<head SHA>.diff`. Three dots, so a force push
   diffs from the merge base rather than producing nonsense. Fall back
   to the full PR diff against `origin/<base>` if it fails anyway.
 - `git -C reviews/<owner>/<repo> log <prev>..HEAD` for the new commit

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -248,7 +248,8 @@ impl Policy {
     /// evaluate.
     pub fn child_exec(workspace: &Path) -> Self {
         use crate::workspace::{
-            CONTEXT_DIR, LCM_DIR, LCM_PAYLOADS_DIR, PROJECTS_DIR, REVIEW_CHECKLIST, STATE_DIR,
+            CONTEXT_DIR, DIFFS_DIR, LCM_DIR, LCM_PAYLOADS_DIR, PROJECTS_DIR, REVIEW_CHECKLIST,
+            STATE_DIR,
         };
 
         let all = AccessFs::from_all(ABI_VERSION);
@@ -266,6 +267,14 @@ impl Policy {
                 access: all,
                 presence: Presence::Optional,
                 rationale: "Projects — full access for builds and checkouts",
+            },
+            // Optional like every child rule (a missing path skips the
+            // grant, never aborts the spawn); workspace init creates it.
+            Rule {
+                path: workspace.join(DIFFS_DIR),
+                access: all,
+                presence: Presence::Optional,
+                rationale: "Packed review diffs — exec redirects write here (spec 20)",
             },
             Rule {
                 path: workspace.join(STATE_DIR).join(REVIEW_CHECKLIST),
@@ -949,10 +958,10 @@ mod tests {
     #[test]
     fn child_expected_rule_count() {
         let policy = child_policy();
-        // workspace root, projects, review checklist, payload store,
-        // 5 build caches, /nix/store, /tmp, /etc, /lib64, /run, /dev,
-        // /proc
-        assert_eq!(policy.rules().len(), 16);
+        // workspace root, projects, diffs, review checklist, payload
+        // store, 5 build caches, /nix/store, /tmp, /etc, /lib64, /run,
+        // /dev, /proc
+        assert_eq!(policy.rules().len(), 17);
     }
 
     #[test]

--- a/src/tools/exec.rs
+++ b/src/tools/exec.rs
@@ -762,14 +762,23 @@ fn resolve_working_dir(workspace_root: &Path, dir: Option<&str>) -> Result<PathB
             guidance: "working_dir: path traversal detected".into(),
         });
     }
-    if std::path::Path::new(dir).is_absolute() {
-        return Err(ToolError::Blocked {
-            operation: dir.to_string(),
-            guidance: "working_dir: absolute paths not allowed".into(),
-        });
-    }
+    // Same rule as PathGuard::workspace_relative: the absolute
+    // spelling of an in-workspace dir names the same place.
+    let dir_path = std::path::Path::new(dir);
+    let dir_path = match dir_path.strip_prefix(workspace_root) {
+        Ok(stripped) => stripped,
+        Err(_) if dir_path.is_absolute() => {
+            return Err(ToolError::Blocked {
+                operation: dir.to_string(),
+                guidance: "working_dir: absolute path outside the workspace; \
+                           paths are relative to the workspace root"
+                    .into(),
+            });
+        }
+        Err(_) => dir_path,
+    };
 
-    let resolved = workspace_root.join(dir);
+    let resolved = workspace_root.join(dir_path);
     if !resolved.starts_with(workspace_root) {
         return Err(ToolError::Blocked {
             operation: dir.to_string(),
@@ -1421,6 +1430,22 @@ mod tests {
         let root = Path::new("/workspace");
         assert!(matches!(
             resolve_working_dir(root, Some("/etc")),
+            Err(ToolError::Blocked { .. }),
+        ));
+    }
+
+    /// The absolute spelling of an in-workspace dir names the same
+    /// place (models echo the advertised root, #129); traversal hiding
+    /// in the absolute spelling is still checked first.
+    #[test]
+    fn resolve_working_dir_accepts_absolute_under_root() {
+        let root = Path::new("/workspace");
+        assert_eq!(
+            resolve_working_dir(root, Some("/workspace/projects/myrepo")).unwrap(),
+            Path::new("/workspace/projects/myrepo"),
+        );
+        assert!(matches!(
+            resolve_working_dir(root, Some("/workspace/a/../escape")),
             Err(ToolError::Blocked { .. }),
         ));
     }

--- a/src/tools/path.rs
+++ b/src/tools/path.rs
@@ -62,13 +62,11 @@ impl PathGuard {
         self.resolve_new(path)
     }
 
-    /// The workspace-relative form of `path`. An absolute path under
-    /// the root names the same file as its relative spelling — the
-    /// prompt advertises the root, so models echo it (#129) — and is
-    /// stripped to that spelling; other absolute paths are refused.
-    /// Every consumer (the daemon-owned write fence, the join) must
-    /// see this form, or an absolute spelling would sidestep
-    /// component-based checks.
+    /// The workspace-relative form of `path`: an absolute path under
+    /// the root is stripped to the relative spelling it names; other
+    /// absolute paths are refused. Every consumer (the daemon-owned
+    /// write fence, the join) must see this form, or an absolute
+    /// spelling would sidestep component-based checks.
     fn workspace_relative<'a>(&self, path: &'a str) -> Result<&'a Path, ToolError> {
         match Path::new(path).strip_prefix(&self.root) {
             Ok(stripped) => Ok(stripped),

--- a/src/tools/path.rs
+++ b/src/tools/path.rs
@@ -1,8 +1,10 @@
 //! Workspace-confined path resolution.
 //!
 //! `PathGuard` ensures all tool file operations stay within the workspace root.
-//! Rejects null bytes, `../` traversal, and absolute paths. Canonicalizes the
-//! result and verifies it is under the workspace.
+//! Rejects null bytes, `../` traversal, and absolute paths outside the
+//! workspace; absolute paths under the root are accepted as the relative
+//! spelling they name. Canonicalizes the result and verifies it is under
+//! the workspace.
 
 use std::path::{Path, PathBuf};
 
@@ -50,14 +52,34 @@ impl PathGuard {
 
     /// Like [`PathGuard::resolve`], for tools that modify the file.
     pub fn resolve_writable(&self, path: &str) -> Result<PathBuf, ToolError> {
-        deny_daemon_owned(path)?;
+        deny_daemon_owned(self.workspace_relative(path)?)?;
         self.resolve(path)
     }
 
     /// Like [`PathGuard::resolve_new`], for tools that write the file.
     pub fn resolve_writable_new(&self, path: &str) -> Result<PathBuf, ToolError> {
-        deny_daemon_owned(path)?;
+        deny_daemon_owned(self.workspace_relative(path)?)?;
         self.resolve_new(path)
+    }
+
+    /// The workspace-relative form of `path`. An absolute path under
+    /// the root names the same file as its relative spelling — the
+    /// prompt advertises the root, so models echo it (#129) — and is
+    /// stripped to that spelling; other absolute paths are refused.
+    /// Every consumer (the daemon-owned write fence, the join) must
+    /// see this form, or an absolute spelling would sidestep
+    /// component-based checks.
+    fn workspace_relative<'a>(&self, path: &'a str) -> Result<&'a Path, ToolError> {
+        match Path::new(path).strip_prefix(&self.root) {
+            Ok(stripped) => Ok(stripped),
+            Err(_) if Path::new(path).is_absolute() => Err(ToolError::Blocked {
+                operation: path.to_string(),
+                guidance: "absolute path outside the workspace; paths are \
+                           relative to the workspace root"
+                    .into(),
+            }),
+            Err(_) => Ok(Path::new(path)),
+        }
     }
 
     fn validate_and_join(&self, path: &str) -> Result<PathBuf, ToolError> {
@@ -73,13 +95,7 @@ impl PathGuard {
                 guidance: "path traversal detected".into(),
             });
         }
-        if Path::new(path).is_absolute() {
-            return Err(ToolError::Blocked {
-                operation: path.to_string(),
-                guidance: "absolute paths not allowed".into(),
-            });
-        }
-        Ok(self.root.join(path))
+        Ok(self.root.join(self.workspace_relative(path)?))
     }
 
     fn ensure_under_root(&self, resolved: &Path, original: &str) -> Result<PathBuf, ToolError> {
@@ -95,13 +111,14 @@ impl PathGuard {
 }
 
 /// Reject writes into daemon-owned paths (the `workspace` layout consts:
-/// config, engine context, state). `path` is already validated
-/// (relative, no traversal), so component comparison suffices. The
-/// reviewer escape checklist is the one model-maintained exception.
-fn deny_daemon_owned(path: &str) -> Result<(), ToolError> {
+/// config, engine context, state). `path` is the workspace-relative
+/// form ([`PathGuard::workspace_relative`]) with no traversal, so
+/// component comparison suffices. The reviewer escape checklist is the
+/// one model-maintained exception.
+fn deny_daemon_owned(path: &Path) -> Result<(), ToolError> {
     use crate::workspace::{CONFIG_FILE, CONTEXT_DIR, REVIEW_CHECKLIST, STATE_DIR};
 
-    let components: Vec<&str> = Path::new(path)
+    let components: Vec<&str> = path
         .components()
         .filter_map(|c| match c {
             std::path::Component::Normal(name) => name.to_str(),
@@ -116,7 +133,7 @@ fn deny_daemon_owned(path: &str) -> Result<(), ToolError> {
     }
     if [CONFIG_FILE, CONTEXT_DIR, STATE_DIR].contains(&first) {
         return Err(ToolError::Blocked {
-            operation: format!("write {path}"),
+            operation: format!("write {}", path.display()),
             guidance: format!("{first} is daemon-owned; file tools may read it but not modify it"),
         });
     }
@@ -219,6 +236,56 @@ mod tests {
         let guard = PathGuard::new(dir.path());
         let err = guard.resolve("/etc/passwd").unwrap_err();
         assert!(matches!(err, ToolError::Blocked { .. }));
+    }
+
+    /// The prompt advertises the workspace root, so models echo it;
+    /// the absolute spelling of an in-workspace path names the same
+    /// file and must resolve like its relative form (#129).
+    #[test]
+    fn absolute_path_under_root_resolves() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("foo.txt"), "hello").unwrap();
+
+        let guard = PathGuard::new(dir.path());
+        let root = dir.path().canonicalize().unwrap();
+        let absolute = root.join("foo.txt");
+        assert_eq!(
+            guard.resolve(absolute.to_str().unwrap()).unwrap(),
+            guard.resolve("foo.txt").unwrap(),
+        );
+    }
+
+    /// The daemon-owned write fence compares path components; the
+    /// absolute spelling must be normalized before that comparison or
+    /// it would sidestep the fence.
+    #[test]
+    fn absolute_spelling_cannot_bypass_daemon_owned_fence() {
+        let dir = tempfile::tempdir().unwrap();
+        let guard = PathGuard::new(dir.path());
+        let root = dir.path().canonicalize().unwrap();
+        let absolute = root.join("state/hack.txt");
+        let err = guard
+            .resolve_writable_new(absolute.to_str().unwrap())
+            .unwrap_err();
+        assert!(
+            matches!(&err, ToolError::Blocked { guidance, .. } if guidance.contains("daemon-owned")),
+            "{err}"
+        );
+    }
+
+    /// Traversal hides in absolute spellings too; the check runs on
+    /// the original string, before prefix stripping.
+    #[test]
+    fn absolute_path_with_traversal_still_blocked() {
+        let dir = tempfile::tempdir().unwrap();
+        let guard = PathGuard::new(dir.path());
+        let root = dir.path().canonicalize().unwrap();
+        let sneaky = format!("{}/a/../foo.txt", root.display());
+        let err = guard.resolve(&sneaky).unwrap_err();
+        assert!(
+            matches!(&err, ToolError::Blocked { guidance, .. } if guidance.contains("traversal")),
+            "{err}"
+        );
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -27,6 +27,9 @@ pub const LCM_PAYLOADS_DIR: &str = "payloads";
 pub const PROJECTS_DIR: &str = "projects";
 /// Review worktrees prepared by the GitHub channel live here.
 pub const REVIEWS_DIR: &str = "reviews";
+/// Packed review diffs and conventions, written by exec redirects
+/// (spec 20); outside every checkout so they never dirty a tree.
+pub const DIFFS_DIR: &str = "diffs";
 pub const STATE_DIR: &str = "state";
 /// Ephemeral `GIT_ASKPASS` helpers, relative to [`STATE_DIR`]. Under
 /// `state/` so the exec tier kernel-denies it; the git tier grants it
@@ -84,6 +87,10 @@ impl Workspace {
         mk(&path.join(PROJECTS_DIR))?;
         // The git tier's Landlock rule can only grant an existing path.
         mk(&path.join(REVIEWS_DIR))?;
+        // Same constraint for the exec tier's diffs grant — and the
+        // root is list-only for exec children, so only the daemon can
+        // create it.
+        mk(&path.join(DIFFS_DIR))?;
         mk(&path.join(STATE_DIR))?;
         seed_review_checklist(&path)?;
 


### PR DESCRIPTION
Closes #129.

The #126 review turn burned a tool round on four blocked `file_read`s, each an absolute spelling of a path the guard serves in relative form — the recurring "#70 family" failure. The contradiction was ours: every prompt advertises `Working directory: /var/lib/kitaebot`, models echo paths they are shown, and the guard refused the echo.

Two commits, same theme — stop hiding paths from the model and then punishing it for guessing:

1. **Accept absolute paths under the workspace root.** The blanket rejection was not load-bearing for confinement (`ensure_under_root` canonicalize-checks everything anyway), but it was load-bearing for the daemon-owned write fence, which compares components from the front and ran on the raw string: naive prefix-stripping would have let `/var/lib/kitaebot/state/x` writes walk past it with `var` as the first component. Normalization therefore lives in one function (`workspace_relative`) consumed by both the fence and the join, with a test pinning the bypass shut. Traversal is still checked on the original string; absolute paths outside the root stay blocked with guidance naming the actual problem.
2. **Rename `.diffs/` to `diffs/`.** The review-artifact convention was followed by some turns and freelanced by others (`projects/` dumps, an invented `.diff/run.sh`) — a dotdir is invisible in `ls`, so a model that didn't internalize the protocol never sees the prior art. 683d4cf's location rationale (workspace root, outside every checkout, never dirtying a tree being committed from) is preserved and now stated in spec 20 alongside the why-visible rationale. Existing `.diffs/` files wait for the workspace-hygiene sweep.
