### PR TITLE
Decide exec deny command position with real quoting

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -128,29 +128,37 @@ Executes commands via `bash -c` within the workspace.
 
 **Safety guards — two-layer deny system:**
 
-1. **Regex layer** — a compiled `RegexSet` of ~70+ patterns covering:
-   destructive file ops (`rm -rf`, `shred`, `find -delete`), internal state
+1. **Regex layer** — a compiled `RegexSet` of ~60+ patterns covering:
+   destructive file ops (`rm -rf`, `find -delete`), internal state
    (workspace-root `context/` references except reads of
    `context/lcm/payloads/<file_id>`, which `<file>` references hand to the
    model and the sandbox grants; redirection into `state/`),
-   disk/filesystem (`mkfs`, `dd`, `fdisk`, `mount`), system power
-   (`shutdown`, `reboot`, `systemctl`), privilege escalation (`sudo`, `su`,
-   `chmod`, `chown`),
+   disk/filesystem (`mkfs`, `dd if=`, `fdisk`), system power (`init 0-6`,
+   `systemctl`), privilege escalation (`sudo`, `chmod`, `chown`),
    network exfiltration (`curl -T`, `nc -l`, `socat`), pipe-to-shell
    (`curl|sh`, `wget|sh`), reverse shells (`/dev/tcp/`, python/ruby/perl
    socket), port scanning (`nmap`, `masscan`), secret harvesting
    (`~/.ssh/id_*`, `~/.aws/`), GPG keyring access, process control
-   (`kill -9`), cron persistence, kernel modules, firewall manipulation,
-   injection/escape (`LD_PRELOAD`, `nsenter`), credential probing
-   (`~/.git-credentials`, `credential.helper=` injection), and git
-   operations that must use dedicated tools.
+   (`kill -9`), cron persistence (`crontab`), kernel modules, firewall
+   manipulation, injection/escape (`LD_PRELOAD`, `nsenter`), credential
+   probing (`~/.git-credentials`, `credential.helper=` injection), git
+   operations that must use dedicated tools, and the Nix fences
+   (`nixos-rebuild`, `nix-env`, `nix store delete/gc/optimise`,
+   `nix-channel`, `nix copy --to`, remote flake refs).
 
-2. **Shell-aware structural layer** — tokenizes with `shlex`, strips env var
-   prefixes and path prefixes, matches binary+subcommand. Catches bypass
-   patterns like `VAR=x git commit`, `/usr/bin/git clone`, and
-   piped/chained commands. Includes a full Nix deny list (`nixos-rebuild`,
-   `nix-env`, `nix profile`, `nix store delete/gc`, `nix-collect-garbage`,
-   remote flake refs).
+2. **Shell-aware structural layer** — splits the raw string into
+   simple-command segments on unquoted `|`, `;`, `&`, and newline
+   (a separator inside quotes or after a backslash is an argument),
+   tokenizes each segment with `shlex`, strips env var and path
+   prefixes, and matches binary+subcommand. Catches bypass patterns
+   like `VAR=x git commit`, `/usr/bin/git clone`, and piped/chained
+   commands. Owns every deny rule that is just a binary name in
+   command position (`shred`, `wipe`, `truncate`, `mount`, `umount`,
+   `shutdown`, `reboot`, `poweroff`, `halt`, `su`, `at`): those names
+   double as English prose and grep-pattern text, so command position
+   must be decided with real quoting rules — a regex over the raw
+   string blocked `grep "a\|truncate"` (#135). Also blocks `gh auth`
+   and `nix profile`.
 
 These are defense-in-depth heuristics with friendly error messages. The real
 filesystem boundary is the Landlock sandbox (see [spec 15](15-sandbox.md)).

--- a/src/tools/exec.rs
+++ b/src/tools/exec.rs
@@ -75,22 +75,6 @@ const DENY_RULES: &[DenyRule] = &[
         pattern: r"\bfind\b.*-exec\s+rm\b",
         guidance: BLOCKED,
     },
-    // Bare-name commands are anchored to command position (start or
-    // after a separator): \b alone matches the same names as English
-    // prose inside quoted arguments — a self-analysis turn was once
-    // halted for echoing "not at workspace root".
-    DenyRule {
-        pattern: r"(^|[|;&\n])\s*shred\b",
-        guidance: BLOCKED,
-    },
-    DenyRule {
-        pattern: r"(^|[|;&\n])\s*wipe\b",
-        guidance: BLOCKED,
-    },
-    DenyRule {
-        pattern: r"(^|[|;&\n])\s*truncate\b",
-        guidance: BLOCKED,
-    },
     // Disk / filesystem
     DenyRule {
         pattern: r"\bmkfs\b",
@@ -109,34 +93,10 @@ const DENY_RULES: &[DenyRule] = &[
         guidance: BLOCKED,
     },
     DenyRule {
-        pattern: r"(^|[|;&\n])\s*mount\b",
-        guidance: BLOCKED,
-    },
-    DenyRule {
-        pattern: r"(^|[|;&\n])\s*umount\b",
-        guidance: BLOCKED,
-    },
-    DenyRule {
         pattern: r"(^|[^0-9])>\s*/dev/",
         guidance: BLOCKED,
     },
     // System power
-    DenyRule {
-        pattern: r"(^|[|;&\n])\s*shutdown\b",
-        guidance: BLOCKED,
-    },
-    DenyRule {
-        pattern: r"(^|[|;&\n])\s*reboot\b",
-        guidance: BLOCKED,
-    },
-    DenyRule {
-        pattern: r"(^|[|;&\n])\s*poweroff\b",
-        guidance: BLOCKED,
-    },
-    DenyRule {
-        pattern: r"(^|[|;&\n])\s*halt\b",
-        guidance: BLOCKED,
-    },
     DenyRule {
         pattern: r"\binit\s+[0-6]\b",
         guidance: BLOCKED,
@@ -148,10 +108,6 @@ const DENY_RULES: &[DenyRule] = &[
     // Privilege escalation
     DenyRule {
         pattern: r"\bsudo\b",
-        guidance: BLOCKED,
-    },
-    DenyRule {
-        pattern: r"(^|[|;&\n])\s*su\s",
         guidance: BLOCKED,
     },
     DenyRule {
@@ -330,10 +286,6 @@ const DENY_RULES: &[DenyRule] = &[
     // Cron / persistence
     DenyRule {
         pattern: r"\bcrontab\b",
-        guidance: BLOCKED,
-    },
-    DenyRule {
-        pattern: r"(^|[|;&\n])\s*at\s",
         guidance: BLOCKED,
     },
     // Git operations that must go through their dedicated tools
@@ -859,6 +811,64 @@ const COMMAND_DENY_RULES: &[CommandDeny] = &[
         binary: "nix",
         subcommand: Some("profile"),
         guidance: "use nix develop or nix-shell for ephemeral environments",
+    },
+    // Binaries whose names double as English prose (or grep patterns
+    // naming them): denied here, where command position is decided
+    // with real quoting, not by a regex over the raw string.
+    CommandDeny {
+        binary: "at",
+        subcommand: None,
+        guidance: BLOCKED,
+    },
+    CommandDeny {
+        binary: "halt",
+        subcommand: None,
+        guidance: BLOCKED,
+    },
+    CommandDeny {
+        binary: "mount",
+        subcommand: None,
+        guidance: BLOCKED,
+    },
+    CommandDeny {
+        binary: "poweroff",
+        subcommand: None,
+        guidance: BLOCKED,
+    },
+    CommandDeny {
+        binary: "reboot",
+        subcommand: None,
+        guidance: BLOCKED,
+    },
+    CommandDeny {
+        binary: "shred",
+        subcommand: None,
+        guidance: BLOCKED,
+    },
+    CommandDeny {
+        binary: "shutdown",
+        subcommand: None,
+        guidance: BLOCKED,
+    },
+    CommandDeny {
+        binary: "su",
+        subcommand: None,
+        guidance: BLOCKED,
+    },
+    CommandDeny {
+        binary: "truncate",
+        subcommand: None,
+        guidance: BLOCKED,
+    },
+    CommandDeny {
+        binary: "umount",
+        subcommand: None,
+        guidance: BLOCKED,
+    },
+    CommandDeny {
+        binary: "wipe",
+        subcommand: None,
+        guidance: BLOCKED,
     },
 ];
 
@@ -1753,6 +1763,30 @@ mod tests {
         assert!(command_blocked("echo x|git commit -m hi").is_some());
         assert!(command_blocked("true;gh auth status").is_some());
         assert!(command_blocked("echo hi\ngit push origin main").is_some());
+    }
+
+    #[test]
+    fn quoted_alternations_never_trip_bare_name_rules() {
+        // #135 verbatim: grepping our own source for these words was
+        // blocked because the quoted \| matched the separator anchor.
+        assert_allowed(
+            r#"grep -n "index_over_cap\|compaction\|truncate\|marker" src/memory/mod.rs"#,
+        );
+        // Every bare-name denied binary in one alternation, BRE and ERE.
+        assert_allowed(
+            r#"grep "shred\|wipe\|truncate\|mount\|umount\|shutdown\|reboot\|poweroff\|halt\|su\|at\|dd" f"#,
+        );
+        assert_allowed(
+            r#"grep -E "shred|wipe|truncate|mount|umount|shutdown|reboot|poweroff|halt|su|at|dd" f"#,
+        );
+    }
+
+    #[test]
+    fn bare_name_rules_catch_prefix_bypasses() {
+        // The command-position regexes missed both of these shapes; the
+        // structural rules strip env and path prefixes.
+        assert_blocked("FOO=bar truncate -s 0 file");
+        assert_blocked("/usr/bin/shred secret.txt");
     }
 
     #[test]

--- a/src/tools/exec.rs
+++ b/src/tools/exec.rs
@@ -875,38 +875,58 @@ fn is_env_assignment(token: &str) -> bool {
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
-/// Shell operators that separate simple commands.
-const SHELL_OPERATORS: &[&str] = &["&&", "||", "|", ";"];
+/// Quote state while scanning a raw command string.
+#[derive(PartialEq)]
+enum QuoteState {
+    Double,
+    None,
+    Single,
+}
 
-/// Split a token list on shell operators into individual simple commands.
-fn parse_simple_commands(tokens: &[String]) -> Vec<&[String]> {
-    let mut commands = Vec::new();
-    let mut start = 0;
-    for (i, tok) in tokens.iter().enumerate() {
-        if SHELL_OPERATORS.contains(&tok.as_str()) {
-            if start < i {
-                commands.push(&tokens[start..i]);
+/// Split a command string into simple-command segments on unquoted
+/// separators (`|`, `;`, `&`, newline). Quoting and escapes survive
+/// intact inside each segment for `shlex` to parse; a separator inside
+/// quotes or after a backslash is an argument, not a split point.
+fn split_unquoted_separators(cmd: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut state = QuoteState::None;
+    let mut escaped = false;
+    for c in cmd.chars() {
+        if escaped {
+            escaped = false;
+        } else {
+            match (&state, c) {
+                (QuoteState::Double, '"') | (QuoteState::Single, '\'') => {
+                    state = QuoteState::None;
+                }
+                (QuoteState::Double | QuoteState::None, '\\') => escaped = true,
+                (QuoteState::None, '"') => state = QuoteState::Double,
+                (QuoteState::None, '\'') => state = QuoteState::Single,
+                (QuoteState::None, '|' | ';' | '&' | '\n') => {
+                    segments.push(std::mem::take(&mut current));
+                    continue;
+                }
+                _ => {}
             }
-            start = i + 1;
         }
+        current.push(c);
     }
-    if start < tokens.len() {
-        commands.push(&tokens[start..]);
-    }
-    commands
+    segments.push(current);
+    segments
 }
 
 /// Check a command string against structural deny rules.
 ///
 /// Returns guidance for the first matching rule, or `None`.
 fn command_blocked(cmd: &str) -> Option<&'static str> {
-    let Some(tokens) = shlex::split(cmd) else {
-        return Some("unparseable shell syntax");
-    };
+    for segment in split_unquoted_separators(cmd) {
+        let Some(tokens) = shlex::split(&segment) else {
+            return Some("unparseable shell syntax");
+        };
 
-    for segment in parse_simple_commands(&tokens) {
         // Skip leading KEY=VALUE tokens
-        let rest: Vec<&str> = segment
+        let rest: Vec<&str> = tokens
             .iter()
             .map(String::as_str)
             .skip_while(|t| is_env_assignment(t))
@@ -1663,34 +1683,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_simple_commands() {
-        let tokens: Vec<String> = vec!["echo", "hello", "&&", "git", "commit"]
-            .into_iter()
-            .map(String::from)
-            .collect();
-        let cmds = parse_simple_commands(&tokens);
-        assert_eq!(cmds.len(), 2);
-        assert_eq!(
-            cmds[0].iter().map(String::as_str).collect::<Vec<_>>(),
-            ["echo", "hello"]
-        );
-        assert_eq!(
-            cmds[1].iter().map(String::as_str).collect::<Vec<_>>(),
-            ["git", "commit"]
-        );
-    }
-
-    #[test]
-    fn test_parse_simple_commands_pipe_and_semicolon() {
-        let tokens: Vec<String> = vec!["a", "|", "b", ";", "c", "||", "d"]
-            .into_iter()
-            .map(String::from)
-            .collect();
-        let cmds = parse_simple_commands(&tokens);
-        assert_eq!(cmds.len(), 4);
-    }
-
-    #[test]
     fn test_command_blocked_env_prefix_git_commit() {
         assert_blocked("GIT_CONFIG_GLOBAL=/dev/null git commit -m 'msg'");
     }
@@ -1732,5 +1724,42 @@ mod tests {
         // directly: shlex treats the quoted string as a single token,
         // so `command_blocked` alone should not flag it.
         assert!(command_blocked("echo 'git commit'").is_none());
+    }
+
+    #[test]
+    fn split_unquoted_separators_splits_on_bare_operators() {
+        assert_eq!(
+            split_unquoted_separators("a | b; c && d"),
+            vec!["a ", " b", " c ", "", " d"]
+        );
+        assert_eq!(split_unquoted_separators("a\nb"), vec!["a", "b"]);
+        assert_eq!(split_unquoted_separators("a|b"), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn split_unquoted_separators_keeps_quoted_and_escaped() {
+        assert_eq!(
+            split_unquoted_separators(r#"grep "a\|b" f"#),
+            vec![r#"grep "a\|b" f"#]
+        );
+        assert_eq!(split_unquoted_separators("echo 'a;b'"), vec!["echo 'a;b'"]);
+        assert_eq!(split_unquoted_separators(r"echo \| x"), vec![r"echo \| x"]);
+    }
+
+    #[test]
+    fn test_command_blocked_unspaced_operators() {
+        // Separators split even without surrounding whitespace; shlex
+        // alone would fold `x|git` into one token and miss these.
+        assert!(command_blocked("echo x|git commit -m hi").is_some());
+        assert!(command_blocked("true;gh auth status").is_some());
+        assert!(command_blocked("echo hi\ngit push origin main").is_some());
+    }
+
+    #[test]
+    fn test_command_allowed_quoted_operators_stay_arguments() {
+        // A quoted operator is data, not a separator: what follows it
+        // is not command position.
+        assert!(command_blocked("echo 'x | git commit'").is_none());
+        assert!(command_blocked(r#"grep "a\|b" f | head"#).is_none());
     }
 }

--- a/src/tools/exec.rs
+++ b/src/tools/exec.rs
@@ -1757,6 +1757,33 @@ mod tests {
     }
 
     #[test]
+    fn split_unquoted_separators_escape_semantics() {
+        // An escaped quote does not close the string: | stays quoted.
+        assert_eq!(
+            split_unquoted_separators(r#"echo "a\"b|c""#),
+            vec![r#"echo "a\"b|c""#]
+        );
+        // A double backslash is a complete escape: the separator splits.
+        assert_eq!(
+            split_unquoted_separators(r"echo a\\;reboot"),
+            vec![r"echo a\\", "reboot"]
+        );
+        // Backslash inside single quotes is literal, not an escape.
+        assert_eq!(
+            split_unquoted_separators(r"echo 'a\';reboot"),
+            vec![r"echo 'a\'", "reboot"]
+        );
+    }
+
+    #[test]
+    fn test_command_blocked_background_ampersand() {
+        // A single & separates commands just like &&: the deny rule
+        // fires, not the unparseable-syntax fallback.
+        assert_eq!(command_blocked("true& truncate -s 0 f"), Some(BLOCKED));
+        assert_eq!(command_blocked("sleep 5 & reboot"), Some(BLOCKED));
+    }
+
+    #[test]
     fn test_command_blocked_unspaced_operators() {
         // Separators split even without surrounding whitespace; shlex
         // alone would fold `x|git` into one token and miss these.


### PR DESCRIPTION
Closes #135.

The exec deny regexes anchor bare-name rules to command position with
`(^|[|;&\n])`, which matches the `|` inside a quoted grep alternation.
The bot was blocked grepping its own source for the word truncate. The
regex layer cannot see quoting, so this is unfixable where it lives:
command position has to be decided after real quote handling.

Two commits, in dependency order:

1. **Split structural deny segments with quote awareness.** The
   structural layer used to split on operator *tokens*, which only
   works when the operator is whitespace-separated (`x|truncate` folds
   into one token) and wrongly treats a quoted `"|"` argument as an
   operator once shlex strips quotes. It now splits the raw string on
   unquoted `|`, `;`, `&`, and newline, tracking quote and backslash
   state, then shlex-parses each segment. This has to land first:
   without it, deleting the regex rules would open unspaced-pipe and
   second-line bypasses the regexes currently mask.

2. **Move the bare-name deny rules to the structural layer.** The
   eleven command-position regexes (shred, wipe, truncate, mount,
   umount, shutdown, reboot, poweroff, halt, su, at) become binary-only
   structural rules. This preserves d3117b2's intent (commands, never
   words) with real quoting rules, and closes the env-prefix
   (`FOO=bar truncate`) and path-prefix (`/usr/bin/shred`) bypasses the
   anchored regexes had. Regression test covers the verbatim #135 repro
   plus one alternation naming every moved binary, in both BRE and ERE
   form. Spec 03 updated; it also stops crediting the whole Nix deny
   list to the structural layer (only `nix profile` lives there).

Deliberate tightenings: bare `su` and bare `at` are now blocked (the
old regexes required a trailing space). Known non-goals: the anchored
nix remote-flake regexes share the quoted-false-positive class but need
argument matching the structural layer cannot express; command
substitution (`$(...)`) remains invisible to both layers, as before.
