### PR TITLE
Keep billed usage from failed provider attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ Autonomous programming agent in Rust. Runs in a NixOS VM with Landlock sandboxin
 
 ## Overview
 
-Kitaebot is a long-running daemon that accepts messages via Telegram, Unix socket, GitHub PR comments, GitHub issues, or Linear issues, routes them through an LLM agent loop with tool use, and persists conversation state through a pluggable context engine. A duty scheduler runs recurring work on its own schedule.
+Kitaebot is a long-running daemon that accepts messages via Telegram, Unix socket, GitHub PR comments, GitHub issues, or Linear issues, routes them through an LLM agent loop with tool use, and persists conversation state through a pluggable context engine. A duty scheduler runs recurring work on its own schedule. The agent keeps durable cross-session knowledge in a memory subsystem, reviews its own work through gated reviewer sub-agents, and can consume external MCP tool servers.
 
 Two binaries:
 
 | Binary | Purpose | Lifecycle |
 |--------|---------|-----------|
 | `kitaebot run` | Daemon (Telegram + socket + duties + GitHub PRs/issues + Linear) | systemd service |
+| `kitaebot backup <dir>` | Stage durable workspace state into `<dir>` for archiving | On-demand |
 | `kchat <socket>` | Socket client REPL | On-demand |
 
 ## Architecture
@@ -39,6 +40,22 @@ Conversation state lives behind the `ContextEngine` trait, selected via `context
 
 Sub-agents run on an ephemeral in-memory engine that never compacts.
 
+### Memory
+
+Durable cross-session knowledge lives in `memory/` (spec 21). The index file `memory/MEMORY.md` is read fresh each root turn and appended to the system prompt, so the agent always sees what it knows without a tool call; detail lives in `memory/topics/*.md`, reached with the ordinary file tools. A distillation duty folds recent session history into memory on a schedule, gated by a mechanical token counter (per-session watermarks track what has already been distilled) so a pass only spends an LLM turn when enough new material has accumulated.
+
+### Sub-agents and self-review
+
+The `task` tool delegates to sub-agents: `explore` (read-only research), `worker` (can write files and execute commands), and `reviewer` (read-only judge). Each can run on its own model override.
+
+The review pipeline (spec 23) prompts the agent to have a reviewer sub-agent judge its work at four gates: `plan`, `commit`, `series`, and `pr`. The reviewer ends its response with a fenced `findings` block; the task tool parses it and records verdicts and findings in a review ledger (`/findings` reads it back). Gates are prompted, not enforced — `review.enabled` only controls the recording.
+
+### Duties
+
+The duty scheduler (spec 24) dispatches named units of scheduled work through the agent actor. Schedules are wall-clock with persisted `last_run`, so cadence survives restarts and an overdue duty fires once at startup instead of bursting. Built-ins: `distill` (memory distillation, token-gated), `warm` (re-warms build caches for repos whose HEAD moved), and `self_analysis` (mines the bot's own error tee and journal, proposes fixes as GitHub issues). Operators add `prompt` duties — arbitrary watch-tasks against a trusted repo, optionally gated on `new-commits` so they only fire when the remote head moved.
+
+WARN and ERROR tracing events are mirrored as JSON lines under `state/errors/` (daily rolling files, bounded retention) so the self-analysis duty can read back symptoms that otherwise exist only in journald.
+
 ### Tools
 
 Typed tools replace a generic shell. The LLM declares intent via parameters instead of reasoning about shell syntax.
@@ -65,21 +82,28 @@ Typed tools replace a generic shell. The LLM declares intent via parameters inst
 | `github_pr_reviews` | Fetch PR reviews |
 | `github_pr_diff_comments` | Fetch PR diff comments |
 | `github_pr_diff_reply` | Reply to a PR diff comment |
+| `github_pr_review_submit` | Submit a PR review (approve / request changes / comment) |
+| `github_comment_update` | Edit a previously posted comment |
 | `github_ci_status` | Check CI status for a ref |
 | `github_api` | GitHub REST escape hatch, scoped to the repo |
-| `task` | Delegate to a sub-agent (`explore` read-only research, `worker` implementation) |
+| `linear_set_state` | Move a Linear issue to a named workflow state |
+| `task` | Delegate to a sub-agent (`explore` research, `worker` implementation, `reviewer` judge) |
 | `notify` | Push a message to the user via Telegram (batched by priority) |
 | `lcm_grep` | Search compacted history (LCM engine) |
 | `lcm_describe` | Inspect a compacted node (LCM engine) |
 | `lcm_expand` | Re-expand compacted history (LCM engine, sub-agents only) |
 
-Git and GitHub tools are gated on `git.enabled` and `github.enabled` respectively; `notify` on `telegram.enabled`; the `lcm_*` tools on `context.engine = "lcm"`. Tools can be individually disabled via `tools.disabled`.
+Git and GitHub tools are gated on `git.enabled` and `github.enabled` respectively; `linear_set_state` on `linear.enabled`; `notify` on `telegram.enabled`; the `lcm_*` tools on `context.engine = "lcm"`. Tools can be individually disabled via `tools.disabled`.
 
 All tool outputs pass through `safety::check_tool_output` and execute inside the Landlock sandbox.
 
+### MCP servers
+
+External tool servers speaking MCP (JSON-RPC 2.0 over stdio) can be attached via `mcp.servers` (spec 22). Each server is spawned as a child process; its advertised tools register namespaced as `<server>_<tool>` alongside the built-ins. Per server: an optional `tools` allowlist bounds schema size, `env_credentials` maps environment variables to systemd credentials so secrets never appear in `config.toml`, and `explore = true` admits the server's tools to the read-only sub-agent sets (the operator asserting it has no side effects). The implemented protocol subset is `initialize`, `tools/list`, and `tools/call`.
+
 ### Security model
 
-1. **Landlock sandbox** — Filesystem access restricted to workspace, `/nix/store` (ro), `/tmp`, `/etc` (ro), `/dev`. Applied at startup, inherited by child processes. Every same-uid child that runs repo-influenced code (the exec tool, build-warm commands, and git) additionally re-enforces a tighter tier on itself via the hidden `confine` subcommand: `projects/` stays fully writable, but `state/`, `context/`, `memory/` are neither readable nor writable (one carve-out: `context/lcm/payloads/` is readable, since `<file>` references hand those paths to the model), and the signing keyring lives outside the workspace so no exec child names it at all. The `git` tier additionally grants the keyring and a private askpass helper for signing and authenticated fetches.
+1. **Landlock sandbox** — Filesystem access restricted to workspace, `/nix/store` (ro), `/tmp`, `/etc` (ro), `/dev`. Applied at startup, inherited by child processes. Every same-uid child that runs repo-influenced code (the exec tool, build-warm commands, and git) additionally re-enforces a tighter tier on itself via the hidden `confine` subcommand: `projects/` stays fully writable, but `state/`, `context/`, `memory/` are neither readable nor writable (one carve-out: `context/lcm/payloads/` is readable, since `<file>` references hand those paths to the model), and the signing keyring lives outside the workspace so no exec child names it at all. The `git` tier additionally grants the keyring and a private askpass helper for signing and authenticated fetches. `tools.exec.sandbox` selects the per-child mechanism for exec: `landlock` (default), `bwrap` (bubblewrap namespace view masking daemon-owned paths; needs mount/userns syscalls loosened on the unit), or `none` (children inherit the daemon's Landlock).
 2. **Proxy-based egress filter** — nftables restricts the kitaebot uid to loopback; all outbound HTTP(S) goes through a local tinyproxy that allows CONNECT only to allowlisted hostnames. Prevents prompt-injection-driven exfiltration.
 3. **Leak detection** — Regex scan on tool outputs before they enter the context window.
 4. **Credential isolation** — Secrets loaded via systemd `LoadCredential` before Landlock enforcement. Inaccessible to child processes.
@@ -91,11 +115,14 @@ All tool outputs pass through `safety::check_tool_output` and execute inside the
 
 Any OpenAI-compatible chat completions API. Supported endpoints:
 
-- OpenRouter (default)
+- OpenRouter (default; per-endpoint pricing fetched live for `/usage`)
 - OpenAI
 - Groq
 - Together
 - Mistral
+- Any URL (`provider.api = "https://..."` hits a custom OpenAI-compatible endpoint)
+
+Per-role model overrides route sub-agents, summarization, memory distillation, review, and planning to different models (see `model_overrides` below). Every turn is metered into a per-task usage ledger (spec 27): cost, turns, and wall time, with sub-agent usage rolled up into the parent task; `/usage` reports it.
 
 ## Development
 
@@ -131,10 +158,14 @@ just vm-run --fresh     # Wipe state and restart
 just vm-run --rebuild   # Rebuild and restart
 just chat               # Connect to daemon via SSH socket forwarding
 just ask "message"      # Send one message, print the reply, exit
+just findings           # Show the review ledger (/findings)
 just vm-ssh             # SSH into running VM
 just vm-shell           # Shell as kitaebot daemon user (debugging)
 just vm-logs            # Tail daemon, tinyproxy (refused CONNECTs), and kernel (egress drops) logs
+just vm-logs-dump [n]   # Dump the last n log lines and exit (non-interactive)
 just vm-journal [topic] # Show the bot's work journal (state/JOURNAL.md), optionally one topic
+just vm-backup          # Stage durable state via `kitaebot backup`, tar to backups/ on the host
+just vm-restore FILE    # Restore durable state from a vm-backup artifact
 just vm-stop            # Shut down VM gracefully (pkill fallback)
 ```
 
@@ -225,6 +256,25 @@ kitaebot = {
       trusted_users = [ "user@example.com" ];    # Emails allowed to drive issues
       plan_label = "needs-plan";                 # Labeled issues get plan-first; unlabeled execute directly
     };
+    mcp = {                                      # External MCP tool servers (spec 22)
+      startup_timeout_secs = 30;                 # Spawn + handshake + tools/list budget
+      call_timeout_secs = 60;
+      servers = {
+        bkb = {                                  # Tools register as bkb_*
+          command = "bkb-mcp";                   # Resolved via PATH (add the package to `tools`)
+          args = [ ];
+          env = { };                             # Literal env vars
+          env_credentials = {                    # Env var -> credential file in secretsDir
+            BKB_API_KEY = "bkb-api-key";
+          };
+          tools = [ "search" "lookup_bip" ];     # Allowlist; unset registers all advertised tools
+          explore = true;                        # Admit to read-only sub-agents (asserts no side effects)
+        };
+      };
+    };
+    review = {
+      enabled = true;                            # Record reviewer findings in the review ledger (spec 23)
+    };
     duties = {                                   # Duty scheduler (spec 24)
       distill = { every = "1h"; };                # Token gate still applies
       warm = { every = "24h"; };                  # Build-warm duty; warms repos whose HEAD moved (spec 24)
@@ -277,6 +327,7 @@ kitaebot = {
       disabled = [ "web_search" ];               # Disable specific tools by name
       exec = {
         timeout_secs = 600;
+        sandbox = "landlock";                    # landlock | bwrap | none (per-child confinement)
       };
       web_fetch = {
         timeout_secs = 30;
@@ -314,6 +365,7 @@ Secrets are loaded via systemd `LoadCredential` from `kitaebot.secretsDir`. One 
 | `github-token` | When `git.enabled = true` or `github.enabled = true` |
 | `linear-api-key` | When `linear.enabled = true` |
 | `gpg-signing-key` | When `gitConfig.signingKey` is set |
+| `<name>` | Per `mcp.servers.*.env_credentials` value |
 
 ## Project layout
 
@@ -329,8 +381,10 @@ src/
 │   └── envelope.rs      Envelope, ChannelSource types
 ├── clients/             HTTP client abstractions
 │   ├── chat_completion.rs  OpenAI-compatible API
+│   ├── github.rs           GitHub REST API
 │   ├── telegram.rs         Telegram Bot API
-│   └── linear.rs           Linear GraphQL API
+│   ├── linear.rs           Linear GraphQL API
+│   └── openrouter_pricing.rs  Live per-endpoint rates for /usage
 ├── context/             Context engines (ContextEngine trait)
 │   ├── flat/            Per-name JSON sessions, whole-history compaction
 │   ├── ephemeral.rs     In-memory engine for sub-agents (never compacts)
@@ -342,13 +396,19 @@ src/
 │   ├── file_*.rs        File read/write/edit with PathGuard
 │   ├── glob_search.rs   File pattern matching
 │   ├── grep.rs          Content search (ripgrep backend)
-│   ├── git/             Clone, commit, push, URL validation
-│   ├── github/          PR ops, CI status, REST escape hatch
+│   ├── git/             Clone, commit, push, fixup, rebase, URL validation
+│   ├── github/          PR ops, reviews, CI status, REST escape hatch
+│   ├── linear.rs        linear_set_state
+│   ├── mcp.rs           MCP client (JSON-RPC over stdio) + dynamic tool registration
 │   ├── network/         web_fetch, web_search (Perplexity)
+│   ├── bwrap.rs         Bubblewrap per-child view for exec (sandbox = "bwrap")
+│   ├── warm.rs          Build-cache warmer (spec 03)
 │   ├── cli_runner.rs    Subprocess boundary for git
 │   ├── direnv.rs        Dev environment cache
 │   └── path.rs          PathGuard (traversal rejection)
+├── memory/              Memory subsystem (spec 21): MEMORY.md index + distillation
 ├── sandbox.rs           Landlock policy
+├── confine.rs           Hidden subcommand: per-child Landlock tier, then exec
 ├── safety.rs            Leak detection
 ├── secrets.rs           systemd credential loading
 ├── config.rs            TOML config with validation
@@ -364,9 +424,14 @@ src/
 ├── commands.rs          Slash commands (/new, /project, /context, /compact, /duties, /duty, /distill, /stats, /usage, /findings)
 ├── usage.rs             Usage ledger: per-task cost, turns, wall time (spec 27)
 ├── review.rs            Review ledger: verdicts and findings (spec 23)
-├── state_db.rs          Operational DB handle + migrations (ledgers, cursor docs)
+├── state_db.rs          Operational DB handle (ledgers, cursor docs)
+├── state_db/migrations  Numbered SQL migrations for the state DB
 ├── sqlite.rs            Shared migration ladder mechanics
-├── duty/                Duty scheduler (mod, schedule, state)
+├── duty/                Duty scheduler (schedule, state, self-analysis)
+├── errlog.rs            Error tee: WARN/ERROR events as JSON lines under state/errors/
+├── backup.rs            Durable-state staging for `kitaebot backup` (spec 05)
+├── conventions.rs       Worked repo's AGENTS.md appended to the system prompt
+├── retry.rs             Generic async retry combinator
 ├── runtime.rs           Provider/tools/channels assembly
 ├── activity.rs          Structured turn events for observability
 ├── workspace.rs         Workspace init + system prompt assembly
@@ -375,15 +440,21 @@ src/
 ├── error.rs             Algebraic error types
 └── prompts/             Compiled in via include_str!:
                          SOUL.md, AGENTS.md (root system prompt)
+                         developer-workflow.md, plan-format.md (segments)
                          explore.md, worker.md, reviewer.md (sub-agents)
                          review-gates.md, review-protocol.md (segments)
                          distill.md
 vm/
 ├── configuration.nix    NixOS module (systemd service, egress filter, hardening)
+├── backup.sh            In-VM script: `kitaebot backup` + tar to stdout (fed over ssh)
+├── restore.sh           In-VM script: untar a backup into the workspace
 ├── test-egress.nix      NixOS VM integration test for egress filter
+├── test-backup.nix      NixOS VM integration test for backup/restore
+├── test-flakes.nix      NixOS VM integration test for the daemon's nix toolchain
 ├── test-fixtures/       Test fixture data
 └── prompts/             USER.md (operator file, provisioned)
 nix/
+├── bkb-mcp.nix          Bitcoin knowledge base MCP server package
 └── lightpanda.nix       Headless browser package
 deploy/
 ├── configuration.nix    Host-specific settings (SSH keys, secrets, tools)

--- a/deploy/configuration.nix
+++ b/deploy/configuration.nix
@@ -212,9 +212,13 @@ in
               fix every alert in that directory with native pnpm or
               cargo bumps, run just fix-deps and just check, and open
               ONE pull request for the directory listing the alert
-              numbers it fixes. Push nothing that fails just check
-              locally. End your reply with the number of alerts still
-              open repo-wide.
+              numbers it fixes. Write every alert reference as a
+              markdown link to
+              https://github.com/CumuloGlobal/lightning-node/security/dependabot/<n>
+              — a bare #n in a PR body autolinks to an unrelated issue
+              or PR. Push nothing that fails just check locally. End
+              your reply with the number of alerts still open
+              repo-wide.
 
               Hard rules: one PR or one directory per run. Never touch
               anything under .github/workflows. Never force-push.

--- a/deploy/configuration.nix
+++ b/deploy/configuration.nix
@@ -66,10 +66,10 @@ in
         # tokens per call that 5.2 produced, on every iteration.
         reasoning.effort = "high";
         model_overrides = {
-          explore.model = "deepseek/deepseek-v4-pro";
-          worker.model = "deepseek/deepseek-v4-pro";
+          explore.model = "openai/gpt-5.6-luna";
+          worker.model = "openai/gpt-5.6-luna";
           reviewer.model = "moonshotai/kimi-k3";
-          summarizer.model = "deepseek/deepseek-v4-flash";
+          summarizer.model = "deepseek/deepseek-v4-flash-0731";
           # Distilled facts persist and inject into every future turn;
           # they must not inherit the flash default.
           memory.model = "z-ai/glm-5.3";

--- a/specs/02-provider.md
+++ b/specs/02-provider.md
@@ -13,9 +13,14 @@ OpenAI-compatible chat completions endpoint.
 The `Provider` trait exposes one method:
 
 ```
-chat(messages, tools) -> Result<Response, ProviderError>
+chat(session, messages, tools) -> Result<ChatOutcome, ChatError>
 ```
 
+Both arms carry billed usage: `ChatOutcome` is the reply plus its
+call's usage plus any failed draws' usage; `ChatError` is the final
+error plus the failed draws' usage (see Retry).
+
+`session` is the sticky cache-routing key (OpenRouter `session_id`).
 `messages` is the full context window (system + conversation history).
 `tools` is the set of tool definitions the LLM may invoke. When `tools` is
 empty, the `tools` field is omitted from the wire request entirely.
@@ -106,6 +111,17 @@ provider rather than the agent loop means every consumer (root turns,
 sub-agents, summarizer, heartbeat) gets it for free, and `MockProvider`
 call counts in agent tests stay deterministic. Cancellation needs no
 special handling — dropping the `chat` future drops the sleep with it.
+
+Failed attempts don't unbill their draws (#128). A parse-shaped
+failure (`EmptyResponse`, `Truncated`, `MalformedToolCall`,
+empty-choices `InvalidResponse`) carries the response's usage out of
+the attempt, and `chat` accumulates it across redraws — surfaced in
+`ChatOutcome.failed` on success, or in `ChatError { error, failed }`
+once retries are exhausted, so the ledger records what was billed
+rather than what happened to parse. Transport failures billed nothing
+and contribute nothing. The agent loop folds `failed` into the turn's
+`TurnUsage` on both arms; only the successful draw's `prompt_tokens`
+feeds context-size observation.
 
 No jitter: a single daemon cannot cause a thundering herd.
 

--- a/specs/27-usage.md
+++ b/specs/27-usage.md
@@ -40,7 +40,7 @@ The `turns` table in `state/kitaebot.db` (spec 05), migrations
 | `session` | 0001 | Session the turn ran in; `subagent` for children |
 | `source` | 0001 | `ChannelSource` Display or sub-agent label — display vocabulary, never a grouping key |
 | `model` | 0001 | Provider model id |
-| `calls` | 0001 | Provider calls in the turn |
+| `calls` | 0001 | Billed provider draws in the turn, failed ones included (#128); transport failures billed nothing and don't count |
 | `prompt_tokens`, `completion_tokens` | 0001 | Summed over calls |
 | `cost` | 0001 | USD from the wire (OpenRouter); NULL when unmetered |
 | `task` | 0002 | Task key (below); NULL on legacy rows |

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -310,6 +310,13 @@ impl TurnUsage {
             self.provider = call.provider;
         }
     }
+
+    /// Failed draws are billed draws; they count like any other call.
+    fn add_failed(&mut self, failed: Vec<CallUsage>) {
+        for call in failed {
+            self.add_call(call);
+        }
+    }
 }
 
 /// Everything the ledger records about one finished turn (spec 27):
@@ -530,7 +537,7 @@ async fn turn_loop(
 
         let assembled = engine.assemble(system_prompt).await?;
 
-        let outcome = cancellable(
+        let outcome = match cancellable(
             provider.chat(
                 engine.active_session(),
                 &assembled.messages,
@@ -540,11 +547,22 @@ async fn turn_loop(
             activity_tx,
         )
         .await?
-        .map_err(Error::Provider)?;
+        {
+            Ok(outcome) => outcome,
+            // The turn dies, but its failed draws were billed; the
+            // meter records them on the way out (#128).
+            Err(e) => {
+                stats.usage.add_failed(e.failed);
+                return Err(Error::Provider(e.error));
+            }
+        };
 
         engine.observe_request(assembled.messages, Arc::clone(&tool_definitions));
 
+        stats.usage.add_failed(outcome.failed);
         let call = outcome.usage;
+        // Only the successful draw's prompt size is live context;
+        // failed draws must not inflate it.
         if let Some(prompt_tokens) = call.prompt_tokens {
             engine.observe_tokens(prompt_tokens as usize);
             stats.prompt_tokens = Some(prompt_tokens as usize);
@@ -798,16 +816,23 @@ async fn squeeze(
         })
         .await?;
     let assembled = engine.assemble(system_prompt).await?;
-    let outcome = cancellable(
+    let outcome = match cancellable(
         provider.chat(engine.active_session(), &assembled.messages, &[]),
         &ctx.cancel,
         ctx.activity.as_ref(),
     )
     .await?
-    .map_err(Error::Provider)?;
+    {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            stats.usage.add_failed(e.failed);
+            return Err(Error::Provider(e.error));
+        }
+    };
 
     engine.observe_request(assembled.messages, Arc::from([]));
 
+    stats.usage.add_failed(outcome.failed);
     let call = outcome.usage;
     if let Some(prompt_tokens) = call.prompt_tokens {
         engine.observe_tokens(prompt_tokens as usize);
@@ -1174,6 +1199,24 @@ mod tests {
         assert_eq!(usage.cached_tokens, None);
     }
 
+    #[test]
+    fn turn_usage_failed_draws_count_as_calls() {
+        let mut usage = TurnUsage::default();
+        usage.add_failed(vec![
+            CallUsage {
+                prompt_tokens: Some(100),
+                completion_tokens: 7,
+                cost: Some(0.002),
+                ..CallUsage::default()
+            },
+            CallUsage::default(),
+        ]);
+        assert_eq!(usage.calls, 2);
+        assert_eq!(usage.prompt_tokens, 100);
+        assert_eq!(usage.completion_tokens, 7);
+        assert_eq!(usage.cost, Some(0.002));
+    }
+
     fn text(s: &str) -> Response {
         Response::Text(s.to_string())
     }
@@ -1344,6 +1387,85 @@ mod tests {
 
         assert_eq!(result.unwrap().into_text(), "only response");
         assert_eq!(provider.call_count(), 1);
+    }
+
+    /// A redraw's billed usage reaches the meter alongside the
+    /// successful call (#128).
+    #[tokio::test]
+    async fn meter_bills_failed_draws_on_success() {
+        let provider = Arc::new(
+            MockProvider::new(vec![Ok(text("hi"))])
+                .with_prompt_tokens(200)
+                .with_failed_usage(vec![CallUsage {
+                    prompt_tokens: Some(100),
+                    completion_tokens: 7,
+                    cost: Some(0.002),
+                    ..CallUsage::default()
+                }]),
+        );
+        let tools = Tools::default();
+        let mut engine = test_engine();
+        let summarize = test_summarize(&provider);
+
+        let (result, meter) = run_turn_metered(
+            &mut engine,
+            &summarize,
+            SYSTEM,
+            "Hello",
+            &*provider,
+            &tools,
+            MAX_ITER,
+            BudgetPolicy::Fail,
+            ReplyPolicy::Accept,
+            &ToolCtx::default(),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(meter.usage.calls, 2);
+        assert_eq!(meter.usage.prompt_tokens, 300);
+        assert_eq!(meter.usage.completion_tokens, 7);
+        assert_eq!(meter.usage.cost, Some(0.002));
+    }
+
+    /// A turn that dies on an exhausted provider still bills the
+    /// draws that failed it — the incident behind #128.
+    #[tokio::test]
+    async fn meter_bills_failed_draws_when_the_turn_dies() {
+        let provider = Arc::new(
+            MockProvider::new(vec![Err(ProviderError::EmptyResponse)]).with_failed_usage(vec![
+                CallUsage {
+                    completion_tokens: 3317,
+                    cost: Some(0.004),
+                    ..CallUsage::default()
+                },
+            ]),
+        );
+        let tools = Tools::default();
+        let mut engine = test_engine();
+        let summarize = test_summarize(&provider);
+
+        let (result, meter) = run_turn_metered(
+            &mut engine,
+            &summarize,
+            SYSTEM,
+            "Hello",
+            &*provider,
+            &tools,
+            MAX_ITER,
+            BudgetPolicy::Fail,
+            ReplyPolicy::Accept,
+            &ToolCtx::default(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::Provider(ProviderError::EmptyResponse))
+        ));
+        assert_eq!(meter.usage.calls, 1);
+        assert_eq!(meter.usage.completion_tokens, 3317);
+        assert_eq!(meter.usage.cost, Some(0.004));
     }
 
     #[tokio::test]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -278,7 +278,13 @@ pub fn make_summarize_fn<P: Provider + 'static>(provider: Arc<P>) -> SummarizeFn
         ];
 
         Box::pin(async move {
-            let outcome = provider.chat("summarizer", &prompt_messages, &[]).await?;
+            // Failed-attempt usage is dropped here, as success usage
+            // already is — ledger attribution for summarizer calls is
+            // #139.
+            let outcome = provider
+                .chat("summarizer", &prompt_messages, &[])
+                .await
+                .map_err(|e| e.error)?;
             match outcome.response {
                 Response::Text(text) => Ok(text),
                 Response::ToolCalls { content, .. } => Ok(content),
@@ -311,7 +317,10 @@ pub fn make_raw_chat_fn<P: Provider + 'static>(provider: Arc<P>) -> RawChatFn {
         move |session: String, messages: Vec<Message>, tools: Arc<[ToolDefinition]>| {
             let provider = provider.clone();
             Box::pin(async move {
-                let outcome = provider.chat(&session, &messages, &tools).await?;
+                let outcome = provider
+                    .chat(&session, &messages, &tools)
+                    .await
+                    .map_err(|e| e.error)?;
                 match outcome.response {
                     Response::Text(text) => Ok(text),
                     Response::ToolCalls { content, .. } => Ok(content),

--- a/src/provider/completions.rs
+++ b/src/provider/completions.rs
@@ -15,7 +15,15 @@ use crate::types::{Message, Response, ToolCall, ToolDefinition, ToolFunction};
 
 use super::wire::WireMessage;
 
-use super::{CallUsage, ChatOutcome, Provider};
+use super::{CallUsage, ChatError, ChatOutcome, Provider};
+
+/// One failed round trip and whatever the provider billed for it.
+/// Parse failures keep the usage the response carried; transport
+/// failures billed nothing.
+struct AttemptError {
+    error: ProviderError,
+    usage: Option<CallUsage>,
+}
 
 /// Retries after the initial attempt for transient failures.
 const MAX_RETRIES: u32 = 3;
@@ -151,8 +159,15 @@ impl CompletionsProvider {
     /// This is the unit the retry policy operates on. Parsing belongs
     /// inside it because a response can be faulty in ways the request
     /// is not to blame for, and only a fresh draw fixes those.
-    async fn attempt(&self, request: &ChatRequest<'_>) -> Result<ChatOutcome, ProviderError> {
-        let response = self.client.chat_completions(request).await?;
+    async fn attempt(
+        &self,
+        request: &ChatRequest<'_>,
+    ) -> Result<(Response, CallUsage), AttemptError> {
+        let response = self
+            .client
+            .chat_completions(request)
+            .await
+            .map_err(|error| AttemptError { error, usage: None })?;
         if let Some(usage) = &response.usage {
             debug!(
                 model = %self.model,
@@ -181,10 +196,15 @@ impl CompletionsProvider {
             provider: response.provider.clone(),
             ..usage
         };
-        Ok(ChatOutcome {
-            response: Self::parse_response(response)?,
-            usage,
-        })
+        // A parse failure keeps the usage: the draw was billed even
+        // when nothing usable came back (#128).
+        match Self::parse_response(response) {
+            Ok(response) => Ok((response, usage)),
+            Err(error) => Err(AttemptError {
+                error,
+                usage: Some(usage),
+            }),
+        }
     }
 }
 
@@ -194,7 +214,7 @@ impl Provider for CompletionsProvider {
         session: &str,
         messages: &[Message],
         tools: &[ToolDefinition],
-    ) -> Result<ChatOutcome, ProviderError> {
+    ) -> Result<ChatOutcome, ChatError> {
         let wire_messages: Vec<WireMessage> = messages.iter().map(WireMessage::from).collect();
         let request = ChatRequest {
             model: &self.model,
@@ -216,7 +236,39 @@ impl Provider for CompletionsProvider {
         debug!(model = %self.model, message_count = messages.len(), "Sending chat request");
         trace!(request = %serde_json::to_string(&request).unwrap_or_default(), "Request body");
 
-        crate::retry::retry(|| self.attempt(&request), retry_policy).await
+        // Failed-attempt usage is collected here, outside the retry
+        // unit, so the policy and combinator stay on plain
+        // `ProviderError`. A Mutex only because the future must be
+        // Send; attempts run strictly in sequence.
+        let failed = std::sync::Mutex::new(Vec::new());
+        let failed_ref = &failed;
+        let request = &request;
+        let result = crate::retry::retry(
+            || async move {
+                self.attempt(request).await.map_err(|e| {
+                    if let Some(usage) = e.usage {
+                        failed_ref
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .push(usage);
+                    }
+                    e.error
+                })
+            },
+            retry_policy,
+        )
+        .await;
+        let failed = failed
+            .into_inner()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match result {
+            Ok((response, usage)) => Ok(ChatOutcome {
+                response,
+                usage,
+                failed,
+            }),
+            Err(error) => Err(ChatError { error, failed }),
+        }
     }
 
     fn model(&self) -> &str {
@@ -638,7 +690,8 @@ mod tests {
 
     /// An empty draw is redrawn, not surfaced: parsing lives inside
     /// the retry unit precisely so a bad draw costs one request, not a
-    /// sub-agent's whole context (#120).
+    /// sub-agent's whole context (#120). The failed draw's billed
+    /// usage rides the outcome (#128).
     #[tokio::test(start_paused = true)]
     async fn chat_redraws_empty_responses() {
         use std::sync::atomic::Ordering;
@@ -646,17 +699,24 @@ mod tests {
         let outcome = provider.chat("s", &[], &[]).await.unwrap();
         assert!(matches!(outcome.response, Response::Text(t) if t == "hi"));
         assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(outcome.failed.len(), 1);
+        assert_eq!(outcome.failed[0].prompt_tokens, Some(100));
+        assert_eq!(outcome.failed[0].completion_tokens, 7);
+        assert_eq!(outcome.failed[0].cost, Some(0.002));
     }
 
     /// A provider that only produces empty draws fails through on the
-    /// tighter empty budget, not the full retry budget.
+    /// tighter empty budget, not the full retry budget — and the error
+    /// carries every draw's billed usage (#128).
     #[tokio::test(start_paused = true)]
     async fn chat_bounds_empty_redraws() {
         use std::sync::atomic::Ordering;
         let (provider, calls) = faulty_body_provider(usize::MAX, EMPTY_CONTENT_BODY);
         let err = provider.chat("s", &[], &[]).await.unwrap_err();
-        assert!(matches!(err, ProviderError::EmptyResponse));
+        assert!(matches!(err.error, ProviderError::EmptyResponse));
         assert_eq!(calls.load(Ordering::SeqCst), 1 + EMPTY_RETRIES as usize);
+        assert_eq!(err.failed.len(), 1 + EMPTY_RETRIES as usize);
+        assert!(err.failed.iter().all(|u| u.cost == Some(0.002)));
     }
 
     #[test]
@@ -681,28 +741,30 @@ mod tests {
         use std::sync::atomic::Ordering;
         let (provider, calls) = flaky_provider(usize::MAX, ProviderError::BadRequest("400".into()));
         let err = provider.chat("s", &[], &[]).await.unwrap_err();
-        assert!(matches!(err, ProviderError::BadRequest(_)));
+        assert!(matches!(err.error, ProviderError::BadRequest(_)));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
+    /// Transport failures bill nothing; the error must not fabricate
+    /// usage for them.
     #[tokio::test(start_paused = true)]
     async fn chat_gives_up_after_max_retries() {
         use std::sync::atomic::Ordering;
         let (provider, calls) = flaky_provider(usize::MAX, ProviderError::Network("reset".into()));
         let err = provider.chat("s", &[], &[]).await.unwrap_err();
-        assert!(matches!(err, ProviderError::Network(_)));
+        assert!(matches!(err.error, ProviderError::Network(_)));
         assert_eq!(calls.load(Ordering::SeqCst), 1 + MAX_RETRIES as usize);
+        assert!(err.failed.is_empty());
     }
 
     /// A 200 whose tool name cannot be transmitted back.
     const MALFORMED_NAME_BODY: &str = r#"{"choices":[{"message":{"content":"","tool_calls":[{"id":"c1","function":{"name":"review_disposition</arg_key>","arguments":"{}"}}]}}]}"#;
 
-    /// A 200 with nothing in it.
-    const EMPTY_CONTENT_BODY: &str = r#"{"choices":[{"message":{"content":""}}]}"#;
+    /// A 200 with nothing in it — but billed usage, like the real ones.
+    const EMPTY_CONTENT_BODY: &str = r#"{"choices":[{"message":{"content":""}}],"usage":{"prompt_tokens":100,"completion_tokens":7,"cost":0.002}}"#;
 
     /// A 200 whose generation hit `max_tokens` before any output.
-    const TRUNCATED_BODY: &str =
-        r#"{"choices":[{"message":{"content":""},"finish_reason":"length"}]}"#;
+    const TRUNCATED_BODY: &str = r#"{"choices":[{"message":{"content":""},"finish_reason":"length"}],"usage":{"prompt_tokens":100,"completion_tokens":50,"cost":0.01}}"#;
 
     /// Provider whose client answers 200 with `faulty` for the first
     /// `failures` calls and a usable text response after, counting
@@ -762,8 +824,11 @@ mod tests {
         use std::sync::atomic::Ordering;
         let (provider, calls) = faulty_body_provider(usize::MAX, MALFORMED_NAME_BODY);
         let err = provider.chat("s", &[], &[]).await.unwrap_err();
-        assert!(matches!(err, ProviderError::MalformedToolCall { .. }));
+        assert!(matches!(err.error, ProviderError::MalformedToolCall { .. }));
         assert_eq!(calls.load(Ordering::SeqCst), 1 + MAX_RETRIES as usize);
+        // Usage-less 200s still count their draws, contributing nothing.
+        assert_eq!(err.failed.len(), 1 + MAX_RETRIES as usize);
+        assert!(err.failed.iter().all(|u| u.cost.is_none()));
     }
 
     /// Parsing moved inside the retry unit; that must not make every
@@ -775,8 +840,11 @@ mod tests {
         use std::sync::atomic::Ordering;
         let (provider, calls) = faulty_body_provider(usize::MAX, TRUNCATED_BODY);
         let err = provider.chat("s", &[], &[]).await.unwrap_err();
-        assert!(matches!(err, ProviderError::Truncated));
+        assert!(matches!(err.error, ProviderError::Truncated));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+        // Not retried, but still billed: the one draw's usage is kept.
+        assert_eq!(err.failed.len(), 1);
+        assert_eq!(err.failed[0].completion_tokens, 50);
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/provider/mock.rs
+++ b/src/provider/mock.rs
@@ -7,13 +7,15 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::error::ProviderError;
-use crate::provider::{CallUsage, ChatOutcome, Provider};
+use crate::provider::{CallUsage, ChatError, ChatOutcome, Provider};
 use crate::types::{Message, Response, ToolDefinition};
 
 /// Mock provider that returns pre-configured responses in sequence.
 pub struct MockProvider {
     responses: Vec<Result<Response, ProviderError>>,
     usage: CallUsage,
+    /// Failed-draw usage attached to every reply and error.
+    failed: Vec<CallUsage>,
     call_count: Arc<AtomicUsize>,
     /// Messages of the most recent `chat` call, for request assertions.
     last_messages: Arc<Mutex<Vec<Message>>>,
@@ -24,6 +26,7 @@ impl MockProvider {
         Self {
             responses,
             usage: CallUsage::default(),
+            failed: Vec::new(),
             call_count: Arc::new(AtomicUsize::new(0)),
             last_messages: Arc::new(Mutex::new(Vec::new())),
         }
@@ -32,6 +35,13 @@ impl MockProvider {
     /// Attach a `prompt_tokens` value to every successful response.
     pub fn with_prompt_tokens(mut self, tokens: u32) -> Self {
         self.usage.prompt_tokens = Some(tokens);
+        self
+    }
+
+    /// Attach failed-draw usage to every reply and error, as if each
+    /// chat had burned these draws before resolving.
+    pub fn with_failed_usage(mut self, failed: Vec<CallUsage>) -> Self {
+        self.failed = failed;
         self
     }
 
@@ -56,16 +66,23 @@ impl Provider for MockProvider {
         _session: &str,
         messages: &[Message],
         _tools: &[ToolDefinition],
-    ) -> Result<ChatOutcome, ProviderError> {
+    ) -> Result<ChatOutcome, ChatError> {
         let index = self.call_count.fetch_add(1, Ordering::SeqCst);
         *self
             .last_messages
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = messages.to_vec();
-        self.responses[index].clone().map(|response| ChatOutcome {
-            response,
-            usage: self.usage.clone(),
-        })
+        match self.responses[index].clone() {
+            Ok(response) => Ok(ChatOutcome {
+                response,
+                usage: self.usage.clone(),
+                failed: self.failed.clone(),
+            }),
+            Err(error) => Err(ChatError {
+                error,
+                failed: self.failed.clone(),
+            }),
+        }
     }
 
     #[allow(clippy::unnecessary_literal_bound)] // trait ties the return to &self

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -24,6 +24,24 @@ pub struct ChatOutcome {
     pub response: Response,
     /// Usage as reported by the provider for this call.
     pub usage: CallUsage,
+    /// Usage billed by failed attempts before this reply, in order.
+    /// The draws happened and were billed; the ledger records them
+    /// whether or not one finally parsed (#128).
+    pub failed: Vec<CallUsage>,
+}
+
+/// A chat failure plus the usage its failed attempts billed.
+///
+/// Mirrors [`ChatOutcome`]: exhausting the retry budget does not
+/// unbill the draws, so the usage rides beside the error the same
+/// way it rides beside a reply.
+#[derive(Debug, thiserror::Error)]
+#[error("{error}")]
+pub struct ChatError {
+    /// The failure that ended the chat.
+    pub error: ProviderError,
+    /// Usage billed by the failed attempts, in order.
+    pub failed: Vec<CallUsage>,
 }
 
 /// Per-call usage reported by the provider, when it reports any.
@@ -64,12 +82,13 @@ pub trait Provider: Send + Sync {
     ///
     /// # Returns
     /// Either a text response or tool call requests, with usage metadata.
+    /// Both arms carry the usage billed by failed attempts along the way.
     fn chat(
         &self,
         session: &str,
         messages: &[Message],
         tools: &[ToolDefinition],
-    ) -> impl Future<Output = Result<ChatOutcome, ProviderError>> + Send;
+    ) -> impl Future<Output = Result<ChatOutcome, ChatError>> + Send;
 
     /// The model this provider sends requests as; recorded per turn in
     /// the usage ledger.


### PR DESCRIPTION
## Problem

A failed provider attempt returned `Err(ProviderError)` with no usage attached, so tokens billed for the draw never reached the ledger (#128). `attempt()` built the `CallUsage` before parsing, then discarded it with the parse failure. The 2026-09-01 incident: an `EmptyResponse` after 3317 billed reasoning tokens, invisible in `/usage`. #127 making empties retryable widened the hole, and per-turn cost comparisons were flattered by dropping the cost of exactly the failures cheap models produce more of.

## Change

- Parse-shaped failures (`EmptyResponse`, `Truncated`, `MalformedToolCall`, empty-choices `InvalidResponse`) carry their usage out of `attempt()`; transport failures billed nothing and carry nothing.
- `chat()` accumulates failed-draw usage across redraws: `ChatOutcome` grows a `failed` vector, exhaustion returns `ChatError { error, failed }`. Accumulation lives outside the retry unit, so the combinator and policy stay on plain `ProviderError` and the #120 parse-inside-retry fence is untouched.
- The turn loop folds `failed` into `TurnUsage` on both arms, so failed draws count as calls in the ledger. Only the successful draw's `prompt_tokens` feeds context-size observation.
- Wrapper over usage fields on `ProviderError` variants: keeps the error enum a pure failure-mode ADT, and the final error could only carry its own attempt's usage anyway.
- Specs 02 and 27 updated.

Landed as one commit rather than the planned two: the trait signature change forces the agent-loop edits regardless, and staging `ChatOutcome.failed` without its consumer trips `dead_code`.

The summarizer/raw-chat closures dropping usage even on success is pre-existing, split to #139.

Closes #128