### PR TITLE
Recover unparseable reviewer findings with one corrective retry, and make drops visible

### DIFF
--- a/specs/23-self-review.md
+++ b/specs/23-self-review.md
@@ -341,7 +341,13 @@ mechanical trailer to the reviewer text it hands the parent
 (`[ledger: finding ids 12, 13]`; nothing appended for a clean review
 or a disabled ledger), and `review_log` replies `Recorded finding #N.`
 instead of `Recorded.`. Ids reach the parent as ordinary tool output —
-no side channel, and the parent quotes them back verbatim.
+no side channel, and the parent quotes them back verbatim. Recording
+failure is never silent in the other direction either: an unparseable
+findings block earns one corrective turn, and a residual failure
+appends `[ledger: findings block unparseable; nothing recorded]` (a
+failed ledger write appends `[ledger: recording failed; nothing
+recorded]`) — "recorded" and "dropped" result text is never
+identical, and a failure trailer means no ids exist to disposition.
 
 **Write path**: a root-only `review_disposition` tool
 (`finding_id`, `disposition`, `note`) that can only annotate existing
@@ -443,7 +449,7 @@ that references an unavailable mechanism is worse than none.
 | Failure | Behavior |
 |---------|----------|
 | Reviewer sub-agent errors (overflow, max_iterations, provider) | Tool error text to parent; parent proceeds on its own judgment. A failed review is a skipped review, not a blocked turn. |
-| Findings block missing or malformed | Warning log, no ledger rows; full response text still delivered to parent. |
+| Findings block missing or malformed | One corrective turn on the reviewer's own session ("re-emit the block"); if the retry also fails to parse, warning log plus an explicit `[ledger: findings block unparseable; nothing recorded]` trailer on the task result. The ledger is telemetry; it never blocks work. |
 | Ledger write fails | Warning log, review continues. The ledger is telemetry; it never blocks work. |
 | Reviewer hallucinates a finding | Parent disputes with a reason, as with human feedback. Cost is bounded by the advisory design — no gate blocks on a false positive. |
 | Branch diff too large to pack (series gate) | Parent degrades to commit list + stats; reviewer pulls files itself. |

--- a/specs/23-self-review.md
+++ b/specs/23-self-review.md
@@ -450,7 +450,7 @@ that references an unavailable mechanism is worse than none.
 |---------|----------|
 | Reviewer sub-agent errors (overflow, max_iterations, provider) | Tool error text to parent; parent proceeds on its own judgment. A failed review is a skipped review, not a blocked turn. |
 | Findings block missing or malformed | One corrective turn on the reviewer's own session ("re-emit the block"); if the retry also fails to parse, warning log plus an explicit `[ledger: findings block unparseable; nothing recorded]` trailer on the task result. The ledger is telemetry; it never blocks work. |
-| Ledger write fails | Warning log, review continues. The ledger is telemetry; it never blocks work. |
+| Ledger write fails | Warning log plus an explicit `[ledger: recording failed; nothing recorded]` trailer on the task result. The ledger is telemetry; it never blocks work. |
 | Reviewer hallucinates a finding | Parent disputes with a reason, as with human feedback. Cost is bounded by the advisory design — no gate blocks on a false positive. |
 | Branch diff too large to pack (series gate) | Parent degrades to commit list + stats; reviewer pulls files itself. |
 | `review_log` called with bad arguments | `ToolError::InvalidArguments`, parent retries or skips. |

--- a/src/agent/task.rs
+++ b/src/agent/task.rs
@@ -90,13 +90,8 @@ const FINDINGS_RETRY_PROMPT: &str = "Your previous response had no parseable ```
 block (exactly one fenced block holding a single JSON object). Re-emit your review's \
 verdict and findings as exactly one such block, unchanged in substance, nothing else.";
 
-/// The corrective turn runs with no tool definitions and one
-/// iteration: it can only answer with text, at most one provider call
-/// plus one `FinalAnswer` squeeze. Session histories that hold tool
-/// rounds still carry their `tool_calls` and providers like GLM reject
-/// such a history when the tools are absent from the request; the
-/// failure is soft — a warning and the unparseable trailer, the
-/// parent's text survives.
+/// Toolless and single-iteration: the corrective turn can only
+/// answer with text (see the commit for the GLM tool-history caveat).
 const FINDINGS_RETRY_MAX_ITERATIONS: usize = 1;
 
 /// A sub-agent type: system prompt plus prebuilt tool set.

--- a/src/agent/task.rs
+++ b/src/agent/task.rs
@@ -1230,6 +1230,60 @@ mod tests {
         assert!(!result.contains("[ledger:"), "{result}");
     }
 
+    /// Exercise the ledger-write failure path: the reviews table is
+    /// dropped behind the ledger's back, so `record_review` fails at
+    /// the statement — the same `Err` any schema/IO failure surfaces.
+    #[tokio::test]
+    async fn failed_ledger_write_carries_its_trailer() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Arc::new(crate::review::ReviewLedger::new(
+            &crate::state_db::StateDb::open(&dir.path().join("kitaebot.db")).unwrap(),
+        ));
+        let review = "Bad.\n```findings\n\
+             {\"verdict\": \"incorrect\", \"confidence\": 0.9, \
+             \"explanation\": \"x\", \
+             \"findings\": [{\"category\": \"c\", \"note\": \"n\"}]}\n```";
+        let provider = Arc::new(MockProvider::new(vec![Ok(Response::Text(
+            review.to_string(),
+        ))]));
+        {
+            let conn = ledger.connection_for_test();
+            conn.execute("DROP TABLE reviews", []).unwrap();
+        }
+        let tool = TaskTool::new(
+            same_provider(&provider),
+            noop_summarize(),
+            AgentTypes {
+                explore: agent_type(Tools::default()),
+                worker: agent_type(Tools::default()),
+                reviewer: agent_type(Tools::default()),
+            },
+            5,
+            None,
+            Some(ledger.clone()),
+        );
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "prompt": "review this",
+                    "agent_type": "reviewer",
+                    "review": {"repo": "o/r", "gate": "commit", "git_ref": "abc"}
+                }),
+                ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(provider.call_count(), 1, "no retry on a write failure");
+        assert!(
+            result.contains("[ledger: recording failed; nothing recorded]"),
+            "{result}"
+        );
+        assert!(
+            !result.contains("[ledger: finding ids"),
+            "a failed write must not cite ids: {result}"
+        );
+    }
+
     #[tokio::test]
     async fn clean_review_gets_no_id_trailer() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/agent/task.rs
+++ b/src/agent/task.rs
@@ -27,7 +27,7 @@ use crate::tools::mcp::McpTools;
 use crate::tools::{Tool, ToolCtx, Tools, string_or_value};
 use crate::usage::{self, TurnRecord, UsageLedger};
 
-use super::{BudgetPolicy, ReplyPolicy, run_turn_metered};
+use super::{BudgetPolicy, ReplyPolicy, TurnMeter, run_turn_metered};
 
 /// Allowlist for the `explore` type: read-only research.
 ///
@@ -82,6 +82,13 @@ const EXPLORE_PROMPT: &str = include_str!("../prompts/explore.md");
 const WORKER_PROMPT: &str = include_str!("../prompts/worker.md");
 
 const REVIEWER_PROMPT: &str = include_str!("../prompts/reviewer.md");
+
+/// The corrective turn after an unparseable findings block: the
+/// reviewer sees its own prior text in the session and re-emits the
+/// block; one attempt, no new analysis.
+const FINDINGS_RETRY_PROMPT: &str = "Your previous response had no parseable ```findings \
+block (exactly one fenced block holding a single JSON object). Re-emit your review's \
+verdict and findings as exactly one such block, unchanged in substance, nothing else.";
 
 /// A sub-agent type: system prompt plus prebuilt tool set.
 pub(crate) struct AgentType {
@@ -339,8 +346,55 @@ impl<P: Provider> Tool for TaskTool<P> {
             .instrument(tracing::info_span!("subagent", agent = label))
             .await;
             // Bill before propagating: a sub-agent that errored still
-            // spent its calls. No conversation of its own, so the row is
-            // tagged by agent type.
+            // spent its calls. The reviewer branch's retry spend is
+            // already folded into the meter, so one row bills it all.
+            let output = match result {
+                Ok(output) => output,
+                Err(e) => {
+                    usage::record_turn(
+                        self.usage_ledger.as_deref(),
+                        &TurnRecord {
+                            // Inherited from the parent: sub-agent spend
+                            // folds into the task that delegated it
+                            // (spec 27).
+                            task: ctx.task.as_ref(),
+                            session: "subagent",
+                            source: label,
+                            model: provider.model(),
+                            meter,
+                        },
+                    );
+                    return Err(ToolError::SubAgent {
+                        source: Box::new(e),
+                    });
+                }
+            };
+            let mut text = output.into_text();
+            let mut meter = meter;
+            if args.agent_type == AgentKind::Reviewer {
+                let (recorded, retry_meter) = self
+                    .record_review_with_retry(
+                        ReviewRetry {
+                            engine: &mut engine,
+                            meta: args.review.as_ref(),
+                            provider,
+                            system_prompt: &agent.system_prompt,
+                            tools: &agent.tools,
+                            max_iterations: self.max_iterations,
+                            ctx: &child_ctx,
+                        },
+                        &text,
+                    )
+                    .instrument(tracing::info_span!("subagent", agent = "reviewer-retry"))
+                    .await;
+                append_recording_trailer(&mut text, &recorded);
+                // The retry's spend folds into this gate invocation's
+                // single usage row (spec 27).
+                if let Some(retry) = retry_meter {
+                    meter.usage.add_turn(&retry.usage);
+                    meter.duration += retry.duration;
+                }
+            }
             usage::record_turn(
                 self.usage_ledger.as_deref(),
                 &TurnRecord {
@@ -353,37 +407,119 @@ impl<P: Provider> Tool for TaskTool<P> {
                     meter,
                 },
             );
-            let output = result.map_err(|e| ToolError::SubAgent {
-                source: Box::new(e),
-            })?;
-            let mut text = output.into_text();
-            if args.agent_type == AgentKind::Reviewer {
-                let ids = record_review(self.review_ledger.as_deref(), args.review.as_ref(), &text);
-                if !ids.is_empty() {
-                    let list = ids
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    let _ = write!(text, "\n\n[ledger: finding ids {list}]");
-                }
-            }
             Ok(text)
         })
     }
 }
 
-/// Parse a reviewer response's findings block and record it —
-/// mechanically, no model cooperation required. Telemetry only: every
-/// failure is a warning, never a review failure. Returns the recorded
-/// finding ids so the parent can disposition them.
-fn record_review(ledger: Option<&ReviewLedger>, meta: Option<&ReviewMeta>, text: &str) -> Vec<i64> {
-    let Some(ledger) = ledger else {
-        return Vec::new();
+/// How a reviewer's findings block landed in the ledger. `Disabled` is
+/// a ledger-off no-op, `Recorded` an empty vec on a clean review.
+enum ReviewRecording {
+    Disabled,
+    Recorded(Vec<i64>),
+    Unparseable,
+    WriteFailed,
+}
+
+/// Everything the corrective retry turn needs, borrowed from the
+/// reviewer invocation.
+struct ReviewRetry<'a, P: Provider> {
+    engine: &'a mut EphemeralSession,
+    meta: Option<&'a ReviewMeta>,
+    provider: &'a P,
+    system_prompt: &'a str,
+    tools: &'a Tools,
+    max_iterations: usize,
+    ctx: &'a ToolCtx,
+}
+
+/// A failure trailer means nothing was recorded: the parent must not
+/// cite ids or call `review_disposition` for them. A clean review
+/// (empty `Recorded`) and `Disabled` get no trailer at all.
+fn append_recording_trailer(text: &mut String, recorded: &ReviewRecording) {
+    let trailer = match recorded {
+        ReviewRecording::Recorded(ids) if !ids.is_empty() => {
+            let list = ids
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("\n\n[ledger: finding ids {list}]")
+        }
+        ReviewRecording::Unparseable => {
+            "\n\n[ledger: findings block unparseable; nothing recorded]".to_string()
+        }
+        ReviewRecording::WriteFailed => {
+            "\n\n[ledger: recording failed; nothing recorded]".to_string()
+        }
+        ReviewRecording::Recorded(_) | ReviewRecording::Disabled => return,
     };
+    let _ = write!(text, "{trailer}");
+}
+
+impl<P: Provider> TaskTool<P> {
+    /// Parse a reviewer response's findings block and record it —
+    /// mechanically, no model cooperation required. Telemetry only:
+    /// every failure is a warning, never a review failure. An
+    /// unparseable block gets one corrective turn on the same session
+    /// (the reviewer sees its own text) before giving up; that turn's
+    /// meter comes back for folding into the invocation's usage row.
+    async fn record_review_with_retry(
+        &self,
+        retry: ReviewRetry<'_, P>,
+        text: &str,
+    ) -> (ReviewRecording, Option<TurnMeter>) {
+        let Some(ledger) = self.review_ledger.as_deref() else {
+            return (ReviewRecording::Disabled, None);
+        };
+        match record_parse(ledger, retry.meta, text) {
+            recording @ (ReviewRecording::Recorded(_) | ReviewRecording::WriteFailed) => {
+                (recording, None)
+            }
+            ReviewRecording::Unparseable => {
+                warn!("reviewer response has no parseable findings block; retrying once");
+                let ReviewRetry {
+                    engine,
+                    provider,
+                    system_prompt,
+                    tools,
+                    max_iterations,
+                    ctx,
+                    ..
+                } = retry;
+                let (result, meter) = run_turn_metered(
+                    engine,
+                    &self.summarize,
+                    system_prompt,
+                    FINDINGS_RETRY_PROMPT,
+                    provider,
+                    tools,
+                    max_iterations,
+                    BudgetPolicy::FinalAnswer,
+                    ReplyPolicy::Accept,
+                    ctx,
+                )
+                .await;
+                match result {
+                    Ok(output) => {
+                        let retry_text = output.into_text();
+                        (record_parse(ledger, retry.meta, &retry_text), Some(meter))
+                    }
+                    Err(e) => {
+                        warn!("findings retry turn failed: {e}");
+                        (ReviewRecording::Unparseable, Some(meter))
+                    }
+                }
+            }
+            ReviewRecording::Disabled => (ReviewRecording::Disabled, None),
+        }
+    }
+}
+
+/// Parse `text`'s findings block and write it to the ledger.
+fn record_parse(ledger: &ReviewLedger, meta: Option<&ReviewMeta>, text: &str) -> ReviewRecording {
     let Some(output) = review::parse_findings_block(text) else {
-        warn!("reviewer response has no parseable findings block");
-        return Vec::new();
+        return ReviewRecording::Unparseable;
     };
     // A missing meta mislabels the rows but must not drop them: the
     // category counts are the point.
@@ -399,10 +535,10 @@ fn record_review(ledger: Option<&ReviewLedger>, meta: Option<&ReviewMeta>, text:
         git_ref,
     };
     match ledger.record_review(&record, &output) {
-        Ok(ids) => ids,
+        Ok(ids) => ReviewRecording::Recorded(ids),
         Err(e) => {
             warn!("failed to record review: {e}");
-            Vec::new()
+            ReviewRecording::WriteFailed
         }
     }
 }
@@ -930,6 +1066,170 @@ mod tests {
         assert!(report.contains("swallowed-error"), "{report}");
     }
 
+    /// The incident's real bad shape (issue #113): a dispatch prompt
+    /// respec'd the block into plain verdict/findings prose.
+    const BAD_SHAPE_RESPONSE: &str =
+        "Looks broken.\nverdict: incorrect\nfindings:\n- id: 1\n  note: drops err\n";
+
+    fn malformed_response_provider() -> Arc<MockProvider> {
+        Arc::new(MockProvider::new(vec![
+            Ok(Response::Text(BAD_SHAPE_RESPONSE.to_string())),
+            Ok(Response::Text(REVIEW_RESPONSE.to_string())),
+        ]))
+    }
+
+    #[tokio::test]
+    async fn unparseable_block_retried_once_and_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Arc::new(crate::review::ReviewLedger::new(
+            &crate::state_db::StateDb::open(&dir.path().join("kitaebot.db")).unwrap(),
+        ));
+        let provider = malformed_response_provider();
+        let tool = TaskTool::new(
+            same_provider(&provider),
+            noop_summarize(),
+            AgentTypes {
+                explore: agent_type(Tools::default()),
+                worker: agent_type(Tools::default()),
+                reviewer: agent_type(Tools::default()),
+            },
+            5,
+            None,
+            Some(ledger.clone()),
+        );
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "prompt": "review this",
+                    "agent_type": "reviewer",
+                    "review": {"repo": "o/r", "gate": "commit", "git_ref": "abc"}
+                }),
+                ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+        // Two calls: the review, then the corrective re-emit. The
+        // parent sees the original prose plus the recorded ids.
+        assert_eq!(provider.call_count(), 2, "{result}");
+        assert!(
+            result.contains("verdict: incorrect"),
+            "original prose must reach the parent: {result}"
+        );
+        assert!(result.contains("[ledger: finding ids 1]"), "{result}");
+        let report = ledger.report().unwrap();
+        assert!(report.contains("swallowed-error"), "{report}");
+    }
+
+    #[tokio::test]
+    async fn unparseable_after_retry_carries_the_trailer() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Arc::new(crate::review::ReviewLedger::new(
+            &crate::state_db::StateDb::open(&dir.path().join("kitaebot.db")).unwrap(),
+        ));
+        let provider = Arc::new(MockProvider::new(vec![
+            Ok(Response::Text(BAD_SHAPE_RESPONSE.to_string())),
+            Ok(Response::Text(BAD_SHAPE_RESPONSE.to_string())),
+        ]));
+        let tool = TaskTool::new(
+            same_provider(&provider),
+            noop_summarize(),
+            AgentTypes {
+                explore: agent_type(Tools::default()),
+                worker: agent_type(Tools::default()),
+                reviewer: agent_type(Tools::default()),
+            },
+            5,
+            None,
+            Some(ledger.clone()),
+        );
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "prompt": "review this",
+                    "agent_type": "reviewer",
+                    "review": {"repo": "o/r", "gate": "commit", "git_ref": "abc"}
+                }),
+                ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(provider.call_count(), 2);
+        assert!(
+            result.contains("[ledger: findings block unparseable; nothing recorded]"),
+            "{result}"
+        );
+        assert_eq!(ledger.report().unwrap(), "No reviews recorded.");
+    }
+
+    #[tokio::test]
+    async fn failed_retry_turn_still_delivers_the_review() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Arc::new(crate::review::ReviewLedger::new(
+            &crate::state_db::StateDb::open(&dir.path().join("kitaebot.db")).unwrap(),
+        ));
+        let provider = Arc::new(MockProvider::new(vec![
+            Ok(Response::Text(BAD_SHAPE_RESPONSE.to_string())),
+            Err(ProviderError::RateLimited),
+        ]));
+        let tool = TaskTool::new(
+            same_provider(&provider),
+            noop_summarize(),
+            AgentTypes {
+                explore: agent_type(Tools::default()),
+                worker: agent_type(Tools::default()),
+                reviewer: agent_type(Tools::default()),
+            },
+            5,
+            None,
+            Some(ledger.clone()),
+        );
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "prompt": "review this",
+                    "agent_type": "reviewer",
+                    "review": {"repo": "o/r", "gate": "commit", "git_ref": "abc"}
+                }),
+                ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            result.contains("[ledger: findings block unparseable; nothing recorded]"),
+            "a failed retry must not fail the task: {result}"
+        );
+        assert!(result.contains("verdict: incorrect"), "{result}");
+        assert_eq!(ledger.report().unwrap(), "No reviews recorded.");
+    }
+
+    #[tokio::test]
+    async fn disabled_ledger_makes_no_retry() {
+        let provider = Arc::new(MockProvider::new(vec![Ok(Response::Text(
+            BAD_SHAPE_RESPONSE.to_string(),
+        ))]));
+        let tool = TaskTool::new(
+            same_provider(&provider),
+            noop_summarize(),
+            AgentTypes {
+                explore: agent_type(Tools::default()),
+                worker: agent_type(Tools::default()),
+                reviewer: agent_type(Tools::default()),
+            },
+            5,
+            None,
+            None,
+        );
+        let result = tool
+            .execute(
+                serde_json::json!({"prompt": "review this", "agent_type": "reviewer"}),
+                ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(provider.call_count(), 1, "no retry without a ledger");
+        assert!(!result.contains("[ledger:"), "{result}");
+    }
+
     #[tokio::test]
     async fn clean_review_gets_no_id_trailer() {
         let dir = tempfile::tempdir().unwrap();
@@ -1209,6 +1509,12 @@ mod tests {
         assert!(REVIEWER_PROMPT.contains("```findings"));
         assert!(REVIEWER_PROMPT.contains("verdict"));
         assert!(REVIEWER_PROMPT.contains("must-fix"));
+    }
+
+    #[test]
+    fn findings_retry_prompt_reemits_without_new_analysis() {
+        assert!(FINDINGS_RETRY_PROMPT.contains("```findings"));
+        assert!(FINDINGS_RETRY_PROMPT.contains("unchanged in substance"));
     }
 
     /// A convention file inside the artifact is the author's claim, so

--- a/src/agent/task.rs
+++ b/src/agent/task.rs
@@ -90,6 +90,15 @@ const FINDINGS_RETRY_PROMPT: &str = "Your previous response had no parseable ```
 block (exactly one fenced block holding a single JSON object). Re-emit your review's \
 verdict and findings as exactly one such block, unchanged in substance, nothing else.";
 
+/// The corrective turn runs with no tool definitions and one
+/// iteration: it can only answer with text, at most one provider call
+/// plus one `FinalAnswer` squeeze. Session histories that hold tool
+/// rounds still carry their `tool_calls` and providers like GLM reject
+/// such a history when the tools are absent from the request; the
+/// failure is soft — a warning and the unparseable trailer, the
+/// parent's text survives.
+const FINDINGS_RETRY_MAX_ITERATIONS: usize = 1;
+
 /// A sub-agent type: system prompt plus prebuilt tool set.
 pub(crate) struct AgentType {
     system_prompt: String,
@@ -379,13 +388,10 @@ impl<P: Provider> Tool for TaskTool<P> {
                             meta: args.review.as_ref(),
                             provider,
                             system_prompt: &agent.system_prompt,
-                            tools: &agent.tools,
-                            max_iterations: self.max_iterations,
                             ctx: &child_ctx,
                         },
                         &text,
                     )
-                    .instrument(tracing::info_span!("subagent", agent = "reviewer-retry"))
                     .await;
                 append_recording_trailer(&mut text, &recorded);
                 // The retry's spend folds into this gate invocation's
@@ -412,24 +418,31 @@ impl<P: Provider> Tool for TaskTool<P> {
     }
 }
 
-/// How a reviewer's findings block landed in the ledger. `Disabled` is
-/// a ledger-off no-op, `Recorded` an empty vec on a clean review.
-enum ReviewRecording {
-    Disabled,
+/// How a reviewer response's findings block parsed. `Recorded` is an
+/// empty vec on a clean review.
+enum ParseOutcome {
     Recorded(Vec<i64>),
     Unparseable,
     WriteFailed,
 }
 
+/// How a reviewer's findings block landed in the ledger. `Disabled` is
+/// a ledger-off no-op and wraps only `ParseOutcome`s: parsing happens
+/// after the ledger check, so a parse outcome can never be `Disabled`.
+enum ReviewRecording {
+    Disabled,
+    Parsed(ParseOutcome),
+}
+
 /// Everything the corrective retry turn needs, borrowed from the
-/// reviewer invocation.
+/// reviewer invocation. The retry turn itself runs toolless and
+/// single-iteration (`Tools::default()`, `FINDINGS_RETRY_MAX_ITERATIONS`),
+/// so no tool set or budget is passed here.
 struct ReviewRetry<'a, P: Provider> {
     engine: &'a mut EphemeralSession,
     meta: Option<&'a ReviewMeta>,
     provider: &'a P,
     system_prompt: &'a str,
-    tools: &'a Tools,
-    max_iterations: usize,
     ctx: &'a ToolCtx,
 }
 
@@ -437,8 +450,12 @@ struct ReviewRetry<'a, P: Provider> {
 /// cite ids or call `review_disposition` for them. A clean review
 /// (empty `Recorded`) and `Disabled` get no trailer at all.
 fn append_recording_trailer(text: &mut String, recorded: &ReviewRecording) {
-    let trailer = match recorded {
-        ReviewRecording::Recorded(ids) if !ids.is_empty() => {
+    let outcome = match recorded {
+        ReviewRecording::Disabled => return,
+        ReviewRecording::Parsed(outcome) => outcome,
+    };
+    let trailer = match outcome {
+        ParseOutcome::Recorded(ids) if !ids.is_empty() => {
             let list = ids
                 .iter()
                 .map(ToString::to_string)
@@ -446,13 +463,11 @@ fn append_recording_trailer(text: &mut String, recorded: &ReviewRecording) {
                 .join(", ");
             format!("\n\n[ledger: finding ids {list}]")
         }
-        ReviewRecording::Unparseable => {
+        ParseOutcome::Unparseable => {
             "\n\n[ledger: findings block unparseable; nothing recorded]".to_string()
         }
-        ReviewRecording::WriteFailed => {
-            "\n\n[ledger: recording failed; nothing recorded]".to_string()
-        }
-        ReviewRecording::Recorded(_) | ReviewRecording::Disabled => return,
+        ParseOutcome::WriteFailed => "\n\n[ledger: recording failed; nothing recorded]".to_string(),
+        ParseOutcome::Recorded(_) => return,
     };
     let _ = write!(text, "{trailer}");
 }
@@ -473,17 +488,15 @@ impl<P: Provider> TaskTool<P> {
             return (ReviewRecording::Disabled, None);
         };
         match record_parse(ledger, retry.meta, text) {
-            recording @ (ReviewRecording::Recorded(_) | ReviewRecording::WriteFailed) => {
-                (recording, None)
+            recording @ (ParseOutcome::Recorded(_) | ParseOutcome::WriteFailed) => {
+                (ReviewRecording::Parsed(recording), None)
             }
-            ReviewRecording::Unparseable => {
+            ParseOutcome::Unparseable => {
                 warn!("reviewer response has no parseable findings block; retrying once");
                 let ReviewRetry {
                     engine,
                     provider,
                     system_prompt,
-                    tools,
-                    max_iterations,
                     ctx,
                     ..
                 } = retry;
@@ -493,33 +506,41 @@ impl<P: Provider> TaskTool<P> {
                     system_prompt,
                     FINDINGS_RETRY_PROMPT,
                     provider,
-                    tools,
-                    max_iterations,
+                    // No tool definitions: the corrective turn can only
+                    // answer with text (see FINDINGS_RETRY_MAX_ITERATIONS).
+                    &Tools::default(),
+                    FINDINGS_RETRY_MAX_ITERATIONS,
                     BudgetPolicy::FinalAnswer,
                     ReplyPolicy::Accept,
                     ctx,
                 )
+                .instrument(tracing::info_span!("subagent", agent = "findings-retry"))
                 .await;
                 match result {
                     Ok(output) => {
                         let retry_text = output.into_text();
-                        (record_parse(ledger, retry.meta, &retry_text), Some(meter))
+                        (
+                            ReviewRecording::Parsed(record_parse(ledger, retry.meta, &retry_text)),
+                            Some(meter),
+                        )
                     }
                     Err(e) => {
                         warn!("findings retry turn failed: {e}");
-                        (ReviewRecording::Unparseable, Some(meter))
+                        (
+                            ReviewRecording::Parsed(ParseOutcome::Unparseable),
+                            Some(meter),
+                        )
                     }
                 }
             }
-            ReviewRecording::Disabled => (ReviewRecording::Disabled, None),
         }
     }
 }
 
 /// Parse `text`'s findings block and write it to the ledger.
-fn record_parse(ledger: &ReviewLedger, meta: Option<&ReviewMeta>, text: &str) -> ReviewRecording {
+fn record_parse(ledger: &ReviewLedger, meta: Option<&ReviewMeta>, text: &str) -> ParseOutcome {
     let Some(output) = review::parse_findings_block(text) else {
-        return ReviewRecording::Unparseable;
+        return ParseOutcome::Unparseable;
     };
     // A missing meta mislabels the rows but must not drop them: the
     // category counts are the point.
@@ -535,10 +556,10 @@ fn record_parse(ledger: &ReviewLedger, meta: Option<&ReviewMeta>, text: &str) ->
         git_ref,
     };
     match ledger.record_review(&record, &output) {
-        Ok(ids) => ReviewRecording::Recorded(ids),
+        Ok(ids) => ParseOutcome::Recorded(ids),
         Err(e) => {
             warn!("failed to record review: {e}");
-            ReviewRecording::WriteFailed
+            ParseOutcome::WriteFailed
         }
     }
 }
@@ -630,6 +651,56 @@ mod tests {
 
     fn mock_tools() -> Tools {
         Tools::new(vec![Arc::new(MockTool::new("mock output"))], &[]).unwrap()
+    }
+
+    /// The corrective turn is structural: toolless (no definitions on
+    /// the wire) and single-iteration. A `ToolCalls` retry response gets
+    /// no execution round — only the `FinalAnswer` squeeze can follow —
+    /// so the run is exactly three calls: review, retry, squeeze.
+    #[tokio::test]
+    async fn findings_retry_is_toolless_and_single_iteration() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Arc::new(crate::review::ReviewLedger::new(
+            &crate::state_db::StateDb::open(&dir.path().join("kitaebot.db")).unwrap(),
+        ));
+        let provider = Arc::new(MockProvider::new(vec![
+            Ok(Response::Text(BAD_SHAPE_RESPONSE.to_string())),
+            Ok(mock_tool_calls()),
+            Ok(Response::Text(String::new())),
+        ]));
+        let tool = TaskTool::new(
+            same_provider(&provider),
+            noop_summarize(),
+            AgentTypes {
+                explore: agent_type(Tools::default()),
+                worker: agent_type(Tools::default()),
+                reviewer: agent_type(mock_tools()),
+            },
+            5,
+            None,
+            Some(ledger.clone()),
+        );
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "prompt": "review this",
+                    "agent_type": "reviewer",
+                    "review": {"repo": "o/r", "gate": "commit", "git_ref": "abc"}
+                }),
+                ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+        // Review + retry + FinalAnswer squeeze of the retry's tool
+        // calls: a second loop iteration would have meant a fourth.
+        assert_eq!(provider.call_count(), 3, "{result}");
+        assert!(!provider.request_tools(0).is_empty());
+        assert!(provider.request_tools(1).is_empty());
+        assert!(provider.request_tools(2).is_empty());
+        assert!(
+            result.contains("[ledger: findings block unparseable; nothing recorded]"),
+            "{result}"
+        );
     }
 
     /// Sub-agent rows inherit the parent's task key through the ctx,

--- a/src/prompts/review-gates.md
+++ b/src/prompts/review-gates.md
@@ -51,7 +51,10 @@ with a reason. The verdict is recorded, not enforced. Findings arrive
 with ledger ids (the `[ledger: finding ids ...]` trailer); after
 acting on each one, record your decision with `review_disposition`:
 "fixed" when you changed code, "disputed" with the reason when you
-contest it, "no-action" for an ignored nit.
+contest it, "no-action" for an ignored nit. A trailer reading
+"findings block unparseable" or "recording failed" means nothing was
+recorded: do not cite ids or call `review_disposition` — the findings
+exist only in the reviewer prose you just read.
 
 Convergence: one review per artifact. Never re-dispatch a review of
 your fixes. One exception: a wrong-approach verdict on a plan yields a

--- a/src/prompts/review-protocol.md
+++ b/src/prompts/review-protocol.md
@@ -101,7 +101,10 @@ The reviewer returns prose plus a findings block. You translate it.
   `[ledger: finding ids ...]` trailer. Say which id went with which
   published comment, then leave them undispositioned: a pr-gate finding
   stays pending until its author answers it, and that is not a lapse of
-  yours. Dispositioning happens on the follow-up turn, below.
+  yours. Dispositioning happens on the follow-up turn, below. A trailer
+  reading "findings block unparseable" or "recording failed" means
+  nothing was recorded — publish the findings from the prose alone and
+  cite no ids.
 - If the reviewer call fails, judge the diff yourself and say so in
   the review body. A review the human takes for a second pair of eyes,
   when it never had one, is a lie of omission.

--- a/src/provider/mock.rs
+++ b/src/provider/mock.rs
@@ -21,6 +21,8 @@ pub struct MockProvider {
     call_count: Arc<AtomicUsize>,
     /// Messages of the most recent `chat` call, for request assertions.
     last_messages: Arc<Mutex<Vec<Message>>>,
+    /// Tool definitions of every `chat` call, in call order.
+    requests_tools: Arc<Mutex<Vec<Vec<ToolDefinition>>>>,
     /// Each `chat` call takes one permit first, so a test can hold a
     /// turn in flight.
     gate: Option<Arc<Semaphore>>,
@@ -34,6 +36,7 @@ impl MockProvider {
             failed: Vec::new(),
             call_count: Arc::new(AtomicUsize::new(0)),
             last_messages: Arc::new(Mutex::new(Vec::new())),
+            requests_tools: Arc::new(Mutex::new(Vec::new())),
             gate: None,
         }
     }
@@ -70,6 +73,16 @@ impl MockProvider {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         (!held.is_empty()).then(|| held.clone())
     }
+
+    /// The tool definitions sent with the `index`th `chat` call.
+    pub fn request_tools(&self, index: usize) -> Vec<ToolDefinition> {
+        self.requests_tools
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(index)
+            .cloned()
+            .unwrap_or_default()
+    }
 }
 
 impl Provider for MockProvider {
@@ -77,7 +90,7 @@ impl Provider for MockProvider {
         &self,
         _session: &str,
         messages: &[Message],
-        _tools: &[ToolDefinition],
+        tools: &[ToolDefinition],
     ) -> Result<ChatOutcome, ChatError> {
         let index = self.call_count.fetch_add(1, Ordering::SeqCst);
         if let Some(gate) = &self.gate {
@@ -87,6 +100,10 @@ impl Provider for MockProvider {
             .last_messages
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = messages.to_vec();
+        self.requests_tools
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(tools.to_vec());
         match self.responses[index].clone() {
             Ok(response) => Ok(ChatOutcome {
                 response,

--- a/src/review.rs
+++ b/src/review.rs
@@ -149,6 +149,15 @@ impl ReviewLedger {
         }
     }
 
+    /// Tests sabotage the schema directly; production code goes
+    /// through `record_review` and sees only its `Err`.
+    #[cfg(test)]
+    pub(crate) fn connection_for_test(&self) -> std::sync::MutexGuard<'_, Connection> {
+        self.conn
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     /// Record one gate invocation: the review row plus one finding row
     /// per entry, all `source = 'self'`. One transaction; a gate either
     /// lands whole or not at all. Returns the inserted finding ids so


### PR DESCRIPTION
Closes #113

## Problem

When a reviewer response's fenced `findings` block was absent or malformed, `record_review` dropped it silently: a journal WARN, no ledger rows, and a task result byte-identical to a successful recording. The parent — which cannot see the journal — cited ledger ids that were never inserted and discovered the drop only when `review_disposition` rejected them. That was the 2026-08-27 incident: two real findings lost, two phantom ids cited in a posted PR review.

## Fix

- **One corrective retry.** On an unparseable block with the ledger enabled, one corrective turn runs on the reviewer's *own* ephemeral session (the reviewer sees its prior text and re-emits the block), then the text is re-parsed. No fresh re-review, no config knob — the same bounded-retry doctrine as the distill compaction retry.
- **Failure trailers.** A residual parse failure appends `[ledger: findings block unparseable; nothing recorded]`; a failed ledger write appends `[ledger: recording failed; nothing recorded]`. "Recorded" and "dropped" result text is never identical again, and a failure trailer tells the parent no ids exist to disposition. `review-gates.md` and `review-protocol.md` state this.
- **Parser unchanged** — strict. Accepting a second prose format would license every future shape drift as "supported"; the retry handles the failure class instead.
- **Retry spend folds into the gate invocation's single usage row** via new `TurnUsage::add_turn` (same fold the distill retry uses).
- **Bill-before-propagate preserved**: `record_turn` for a failed sub-agent moved into the error arm, so an errored sub-agent still bills before the error reaches the parent.

Spec 23's failure-mode rows and identity paragraph updated to match.

## Tests

Six new tests in `agent::task`: retry-then-record (2 provider calls, ids trailer on the original prose), residual unparseable after retry (trailer, zero ledger rows), provider-error retry (review still delivered), disabled ledger (no retry, no trailer), retry prompt content, and ledger-write failure (trailer, no ids, no retry — via a dropped `reviews` table behind the ledger's back). The malformed fixture is the incident's real prose shape.

`just check` passes. Plan was posted to the ticket and approved; commit and series gates both run, findings fixed and dispositioned.