### PR TITLE
Drain the in-flight turn on SIGTERM

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Channels (Telegram, Unix socket, GitHub PRs, GitHub issues, Linear, Duties)
            messages tagged by source)
 ```
 
-The agent is an actor (Ryhl pattern) — a spawned tokio task that processes one envelope at a time. Channels hold cloneable `AgentHandle`s and send messages via `send_message()`, awaiting a reply over a oneshot channel. This eliminates session locking: the actor owns the session and processes requests sequentially.
+The agent is an actor (Ryhl pattern) — a spawned tokio task that processes one envelope at a time. Channels hold cloneable `AgentHandle`s and send messages via `send_message()`, awaiting a reply over a oneshot channel. This eliminates session locking: the actor owns the session and processes requests sequentially. SIGTERM drains instead of killing: the channel loops stop, the in-flight turn runs to completion, queued envelopes are refused, then the daemon exits.
 
 The agent loop calls the LLM, dispatches tool calls in parallel, checks outputs for leaked secrets, and repeats until the model produces a final response or hits `max_iterations`.
 

--- a/specs/01-agent-loop.md
+++ b/specs/01-agent-loop.md
@@ -281,6 +281,18 @@ hint for display formatting.
 
 If the actor has shut down, `send_message` returns a synthetic error string.
 
+**Shutdown drains.** `AgentHandle::spawn` also returns the actor task's
+`JoinHandle`. On SIGINT/SIGTERM the daemon stops the channel loops, calls
+`begin_drain()`, drops its handle, and awaits the task. The actor finishes the
+turn it is on (sub-agents are awaited inside the turn, so they finish with it),
+answers every envelope already queued with `Err("Agent draining")` instead of
+running it, and exits when the last sender is gone. Refusing the queue matters:
+its reply channels are dead, so running it would do the work, post nothing, and
+re-dispatch the same event on the next boot into a session that already
+contains it. Channel events lost this way re-dispatch because a dropped poll
+tick never saved its cursor. The systemd unit's `TimeoutStopSec` bounds the
+drain (spec 09); a hung turn still dies there.
+
 ### ChannelSource
 
 Messages are tagged with their origin before entering the session:

--- a/specs/01-agent-loop.md
+++ b/specs/01-agent-loop.md
@@ -284,7 +284,7 @@ If the actor has shut down, `send_message` returns a synthetic error string.
 **Shutdown drains.** `AgentHandle::spawn` also returns the actor task's
 `JoinHandle`. On SIGINT/SIGTERM the daemon stops the channel loops, calls
 `begin_drain()`, drops its handle, and awaits the task. The actor finishes the
-turn it is on (sub-agents are awaited inside the turn, so they finish with it),
+queued input envelopes with `Err("Agent draining")`
 answers every envelope already queued with `Err("Agent draining")` instead of
 running it, and exits when the last sender is gone. Refusing the queue matters:
 its reply channels are dead, so running it would do the work, post nothing, and

--- a/specs/09-vm.md
+++ b/specs/09-vm.md
@@ -53,6 +53,10 @@ The daemon runs as a systemd service (`Type=simple`):
 - **WorkingDirectory**: `/var/lib/kitaebot`
 - **RuntimeDirectory**: `kitaebot` (creates `/run/kitaebot/` for the socket)
 - **Restart**: `on-failure`, 10s delay
+- **Stop**: `KillMode=mixed`, `TimeoutStopSec=30min`. SIGTERM reaches the
+  daemon alone, which drains the in-flight turn (spec 01); tool children and
+  MCP servers keep running under it and are SIGKILLed with anything left once
+  it exits. A turn still running at the bound is killed.
 - **TasksMax/LimitNPROC**: 4096
 - **Environment**: `KITAEBOT_WORKSPACE`, `RUST_LOG`, `PATH` (restricted to
   the runtime dependencies plus `tools` packages' bin dirs),

--- a/src/agent/actor.rs
+++ b/src/agent/actor.rs
@@ -23,6 +23,7 @@ use crate::tools::Tools;
 use crate::usage::{self, TaskKey, TurnRecord, UsageLedger};
 use crate::workspace::Workspace;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 use super::PromptConfig;
 use super::envelope::{ChannelSource, Envelope, InputEnvelope, TurnRole};
@@ -32,6 +33,8 @@ use super::envelope::{ChannelSource, Envelope, InputEnvelope, TurnRole};
 /// Owns all dependencies so the run loop has no borrows and is `'static`.
 pub(super) struct Agent<P: Provider, E: ContextEngine> {
     rx: mpsc::Receiver<Envelope>,
+    /// Cancelled once shutdown begins; queued input is then refused.
+    drain: CancellationToken,
     workspace: Arc<Workspace>,
     provider: Arc<P>,
     /// Serves [`TurnRole::Planner`] turns; the default provider when
@@ -56,6 +59,7 @@ impl<P: Provider + 'static, E: ContextEngine + 'static> Agent<P, E> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         rx: mpsc::Receiver<Envelope>,
+        drain: CancellationToken,
         workspace: Arc<Workspace>,
         provider: Arc<P>,
         planner_provider: Arc<P>,
@@ -73,6 +77,7 @@ impl<P: Provider + 'static, E: ContextEngine + 'static> Agent<P, E> {
     ) -> Self {
         Self {
             rx,
+            drain,
             workspace,
             provider,
             planner_provider,
@@ -91,10 +96,18 @@ impl<P: Provider + 'static, E: ContextEngine + 'static> Agent<P, E> {
         }
     }
 
-    /// Consume envelopes until all handles are dropped.
+    /// Consume envelopes until all handles are dropped. Once draining,
+    /// queued input is refused: its reply channel is dead by then, and
+    /// the channel re-dispatches the event on the next boot.
     pub async fn run(mut self) {
         while let Some(envelope) = self.rx.recv().await {
             match envelope {
+                Envelope::Greeting(reply_tx) => {
+                    let _ = reply_tx.send(self.format_greeting());
+                }
+                Envelope::Input(input) if self.drain.is_cancelled() => {
+                    let _ = input.reply_tx.send(Err("Agent draining".into()));
+                }
                 Envelope::Input(input) => {
                     // Every event inside the turn inherits this span;
                     // `session` is recorded once the target is known.
@@ -130,9 +143,6 @@ impl<P: Provider + 'static, E: ContextEngine + 'static> Agent<P, E> {
                     } else {
                         tracing::debug!("mailbox non-empty; deferring between-turns compaction");
                     }
-                }
-                Envelope::Greeting(reply_tx) => {
-                    let _ = reply_tx.send(self.format_greeting());
                 }
             }
         }
@@ -390,7 +400,6 @@ mod tests {
     use crate::provider::MockProvider;
     use crate::test_support::{TestAgent, workspace};
     use crate::types::Response;
-    use tokio_util::sync::CancellationToken;
 
     fn spawn_agent(ws: Arc<Workspace>, provider: Arc<MockProvider>) -> AgentHandle {
         spawn_agent_with(ws, provider, Tools::default(), None, 1)
@@ -1124,5 +1133,54 @@ mod tests {
             reply.content
         );
         assert!(rx.try_recv().is_err(), "unknown names must not queue");
+    }
+
+    /// Drain: the in-flight turn completes, the queued one is refused
+    /// without running, and the actor exits once the handle is gone.
+    #[tokio::test]
+    async fn drain_finishes_in_flight_turn_and_refuses_queued() {
+        use tokio::sync::Semaphore;
+
+        let (_dir, ws) = workspace();
+        let gate = Arc::new(Semaphore::new(0));
+        let provider = Arc::new(
+            MockProvider::new(vec![
+                Ok(Response::Text("first".into())),
+                Ok(Response::Text("second".into())),
+            ])
+            .gated(gate.clone()),
+        );
+        let (handle, actor) = TestAgent::new(ws, provider.clone()).spawn_with_task();
+
+        let send = |h: AgentHandle, text: &str| {
+            let text = text.to_string();
+            tokio::spawn(async move {
+                h.send_message(
+                    ChannelSource::Socket,
+                    text,
+                    None,
+                    None,
+                    CancellationToken::new(),
+                )
+                .await
+            })
+        };
+        let first = send(handle.clone(), "one");
+        while provider.call_count() == 0 {
+            tokio::task::yield_now().await;
+        }
+        let second = send(handle.clone(), "two");
+        // Current-thread runtime: one yield runs the spawned send, so
+        // "two" sits in the mailbox before the drain begins.
+        tokio::task::yield_now().await;
+
+        handle.begin_drain();
+        drop(handle);
+        gate.add_permits(1);
+
+        assert_eq!(first.await.unwrap().unwrap().content, "first");
+        assert_eq!(second.await.unwrap().unwrap_err(), "Agent draining");
+        actor.await.unwrap();
+        assert_eq!(provider.call_count(), 1);
     }
 }

--- a/src/agent/handle.rs
+++ b/src/agent/handle.rs
@@ -7,6 +7,7 @@
 use std::sync::Arc;
 
 use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::activity::Activity;
@@ -32,10 +33,14 @@ use super::envelope::{ChannelSource, Envelope, InputEnvelope, TurnRole};
 #[derive(Clone)]
 pub struct AgentHandle {
     tx: mpsc::Sender<Envelope>,
+    /// Cancelled by [`Self::begin_drain`]; the actor then refuses
+    /// queued input instead of running it.
+    drain: CancellationToken,
 }
 
 impl AgentHandle {
-    /// Spawn the agent actor and return a handle to it.
+    /// Spawn the agent actor and return a handle to it plus the
+    /// actor's task, for a shutdown that waits on the in-flight turn.
     ///
     /// The actor task runs until all handles are dropped.
     #[allow(clippy::too_many_arguments)]
@@ -54,10 +59,12 @@ impl AgentHandle {
         usage_ledger: Option<Arc<UsageLedger>>,
         review_ledger: Option<Arc<ReviewLedger>>,
         duty_trigger: Option<TriggerHandle>,
-    ) -> Self {
+    ) -> (Self, JoinHandle<()>) {
         let (tx, rx) = mpsc::channel(32);
+        let drain = CancellationToken::new();
         let actor = Agent::new(
             rx,
+            drain.clone(),
             workspace,
             provider,
             planner_provider,
@@ -73,14 +80,24 @@ impl AgentHandle {
             review_ledger,
             duty_trigger,
         );
-        tokio::spawn(actor.run());
-        Self { tx }
+        let task = tokio::spawn(actor.run());
+        (Self { tx, drain }, task)
     }
 
     /// Create a handle wrapping an existing sender.
     #[cfg(test)]
     pub(super) fn new(tx: mpsc::Sender<Envelope>) -> Self {
-        Self { tx }
+        Self {
+            tx,
+            drain: CancellationToken::new(),
+        }
+    }
+
+    /// Stop accepting work: the in-flight turn completes, envelopes
+    /// already queued are answered with an error, nothing new runs.
+    /// Drop every handle afterwards so the actor's task exits.
+    pub fn begin_drain(&self) {
+        self.drain.cancel();
     }
 
     /// Send a message to the agent and await the reply.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12,12 +12,15 @@
 //!
 //! The core loop ([`run_with_shutdown`]) is generic over its shutdown
 //! future so tests can substitute a simple `sleep` instead of real
-//! Unix signals.
+//! Unix signals. Shutdown drains rather than kills: the loops stop
+//! producing, the actor finishes the turn it is on, and only then does
+//! the daemon return.
 
 use std::future::Future;
 use std::path::Path;
 
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tracing::{error, info};
 
 use crate::agent::AgentHandle;
@@ -32,12 +35,14 @@ use crate::state_db::StateDb;
 use crate::tools::git::GitCli;
 use crate::workspace::Workspace;
 
-/// Production entry point — runs until SIGINT or SIGTERM.
+/// Production entry point — runs until SIGINT or SIGTERM, then until
+/// the in-flight turn completes.
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     workspace: &Workspace,
     state_db: &StateDb,
-    handle: &AgentHandle,
+    handle: AgentHandle,
+    actor: JoinHandle<()>,
     duties: Vec<Duty>,
     telegram: Option<&TelegramChannel>,
     github_client: Option<&GithubClient>,
@@ -52,6 +57,7 @@ pub async fn run(
         workspace,
         state_db,
         handle,
+        actor,
         duties,
         telegram,
         github_client,
@@ -67,9 +73,58 @@ pub async fn run(
 }
 
 /// Testable core: runs duties + github + linear + telegram + socket
-/// until `shutdown` resolves.
+/// until `shutdown` resolves, then drains the actor.
+///
+/// The loops are dropped before the drain, so nothing new is queued
+/// while the actor finishes; a dropped poll tick never saved its
+/// cursor, so its events re-dispatch on the next boot.
 #[allow(clippy::too_many_arguments)]
 async fn run_with_shutdown<S: Future<Output = ()>>(
+    workspace: &Workspace,
+    state_db: &StateDb,
+    handle: AgentHandle,
+    actor: JoinHandle<()>,
+    duties: Vec<Duty>,
+    telegram: Option<&TelegramChannel>,
+    github_client: Option<&GithubClient>,
+    git_cli: Option<&GitCli>,
+    github: &GithubConfig,
+    repos: &[String],
+    linear: Option<&LinearChannel>,
+    socket_cfg: &SocketConfig,
+    shutdown: S,
+    duty_triggers: mpsc::Receiver<duty::Trigger>,
+) {
+    Box::pin(serve_until(
+        workspace,
+        state_db,
+        &handle,
+        duties,
+        telegram,
+        github_client,
+        git_cli,
+        github,
+        repos,
+        linear,
+        socket_cfg,
+        shutdown,
+        duty_triggers,
+    ))
+    .await;
+
+    handle.begin_drain();
+    // The actor exits once the last sender is gone; this is it.
+    drop(handle);
+    info!("Draining: waiting for the in-flight turn to finish.");
+    if let Err(e) = actor.await {
+        error!("agent actor task failed during drain: {e}");
+    }
+    info!("Drain complete, exiting.");
+}
+
+/// The channel loops, racing `shutdown`.
+#[allow(clippy::too_many_arguments)]
+async fn serve_until<S: Future<Output = ()>>(
     workspace: &Workspace,
     state_db: &StateDb,
     handle: &AgentHandle,
@@ -144,7 +199,7 @@ async fn run_with_shutdown<S: Future<Output = ()>>(
         () = linear_loop => unreachable!("linear loop never exits"),
         () = socket_loop => unreachable!("socket loop never exits"),
         () = shutdown => {
-            info!("Shutdown signal received, exiting.");
+            info!("Shutdown signal received.");
             let _ = std::fs::remove_file(socket_path);
         }
     }
@@ -182,8 +237,11 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    fn spawn_agent(ws: &Arc<Workspace>, provider: Arc<MockProvider>) -> AgentHandle {
-        TestAgent::new(ws.clone(), provider).spawn()
+    fn spawn_agent(
+        ws: &Arc<Workspace>,
+        provider: Arc<MockProvider>,
+    ) -> (AgentHandle, JoinHandle<()>) {
+        TestAgent::new(ws.clone(), provider).spawn_with_task()
     }
 
     /// One hourly distill duty. With no persisted state it is due
@@ -215,12 +273,13 @@ mod tests {
         let (_dir, ws) = workspace();
         let (_sock_dir, sock) = sock_config();
         // Closed distill gate → gate-closed reply, but the duty fired.
-        let handle = spawn_agent(&ws, Arc::new(MockProvider::new(vec![])));
+        let (handle, actor) = spawn_agent(&ws, Arc::new(MockProvider::new(vec![])));
 
         Box::pin(run_with_shutdown(
             &ws,
             &StateDb::open_in_memory().unwrap(),
-            &handle,
+            handle,
+            actor,
             distill_duty(),
             None,
             None,
@@ -242,13 +301,14 @@ mod tests {
     async fn duty_run_persists_state() {
         let (_dir, ws) = workspace();
         let (_sock_dir, sock) = sock_config();
-        let handle = spawn_agent(&ws, Arc::new(MockProvider::new(vec![])));
+        let (handle, actor) = spawn_agent(&ws, Arc::new(MockProvider::new(vec![])));
         let state_db = StateDb::open(&ws.state_db_path()).unwrap();
 
         Box::pin(run_with_shutdown(
             &ws,
             &state_db,
-            &handle,
+            handle,
+            actor,
             distill_duty(),
             None,
             None,
@@ -275,12 +335,13 @@ mod tests {
 
         // An unknown duty makes the turn fail — the loop must survive,
         // record the run, and move on.
-        let handle = spawn_agent(&ws, Arc::new(MockProvider::new(vec![])));
+        let (handle, actor) = spawn_agent(&ws, Arc::new(MockProvider::new(vec![])));
 
         Box::pin(run_with_shutdown(
             &ws,
             &StateDb::open_in_memory().unwrap(),
-            &handle,
+            handle,
+            actor,
             vec![Duty {
                 name: "nope".into(),
                 action: duty::Action::Dispatch {

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ async fn daemon_main() {
             let summarizer = config.provider.model_overrides.summarizer.as_ref();
             let summarize = context::make_summarize_fn(role_provider(&provider, summarizer));
 
-            let handle = build_handle(
+            let (handle, actor) = build_handle(
                 workspace.clone(),
                 &state_db,
                 provider,
@@ -152,7 +152,8 @@ async fn daemon_main() {
             Box::pin(daemon::run(
                 &workspace,
                 &state_db,
-                &handle,
+                handle,
+                actor,
                 duties,
                 rt.telegram.as_ref(),
                 rt.github.as_ref(),
@@ -224,7 +225,7 @@ fn build_handle(
     summarize: context::SummarizeFn,
     notifier: Option<Arc<notify::Notifier>>,
     duty_trigger: duty::TriggerHandle,
-) -> agent::AgentHandle {
+) -> (agent::AgentHandle, tokio::task::JoinHandle<()>) {
     let context = config.effective_context();
     match context.engine {
         EngineKind::Flat => {
@@ -377,7 +378,7 @@ fn spawn_with_engine<E: ContextEngine + 'static>(
     summarize: context::SummarizeFn,
     notifier: Option<Arc<notify::Notifier>>,
     duty_trigger: Option<duty::TriggerHandle>,
-) -> agent::AgentHandle {
+) -> (agent::AgentHandle, tokio::task::JoinHandle<()>) {
     // Namespacing makes collisions unlikely; if one happens anyway,
     // the built-in wins and the MCP tool is dropped everywhere.
     let mcp = mcp.without_collisions(&tools);

--- a/src/provider/mock.rs
+++ b/src/provider/mock.rs
@@ -6,6 +6,8 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
+use tokio::sync::Semaphore;
+
 use crate::error::ProviderError;
 use crate::provider::{CallUsage, ChatError, ChatOutcome, Provider};
 use crate::types::{Message, Response, ToolDefinition};
@@ -19,6 +21,9 @@ pub struct MockProvider {
     call_count: Arc<AtomicUsize>,
     /// Messages of the most recent `chat` call, for request assertions.
     last_messages: Arc<Mutex<Vec<Message>>>,
+    /// Each `chat` call takes one permit first, so a test can hold a
+    /// turn in flight.
+    gate: Option<Arc<Semaphore>>,
 }
 
 impl MockProvider {
@@ -29,7 +34,14 @@ impl MockProvider {
             failed: Vec::new(),
             call_count: Arc::new(AtomicUsize::new(0)),
             last_messages: Arc::new(Mutex::new(Vec::new())),
+            gate: None,
         }
+    }
+
+    /// Block every `chat` call until the test adds a permit to `gate`.
+    pub fn gated(mut self, gate: Arc<Semaphore>) -> Self {
+        self.gate = Some(gate);
+        self
     }
 
     /// Attach a `prompt_tokens` value to every successful response.
@@ -68,6 +80,9 @@ impl Provider for MockProvider {
         _tools: &[ToolDefinition],
     ) -> Result<ChatOutcome, ChatError> {
         let index = self.call_count.fetch_add(1, Ordering::SeqCst);
+        if let Some(gate) = &self.gate {
+            gate.acquire().await.expect("gate never closed").forget();
+        }
         *self
             .last_messages
             .lock()

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -85,6 +85,11 @@ impl TestAgent {
     }
 
     pub(crate) fn spawn(self) -> AgentHandle {
+        self.spawn_with_task().0
+    }
+
+    /// [`Self::spawn`] keeping the actor's task, for shutdown tests.
+    pub(crate) fn spawn_with_task(self) -> (AgentHandle, tokio::task::JoinHandle<()>) {
         let engine = FlatSession::new(&self.ws.context_dir(), ContextConfig::default()).unwrap();
         let summarize = make_summarize_fn(self.provider.clone());
         // Threshold far above any test transcript, so a duty turn

--- a/vm/configuration.nix
+++ b/vm/configuration.nix
@@ -372,6 +372,12 @@ in
             ExecStart = "${config.kitaebot.package}/bin/kitaebot run";
             Restart = "on-failure";
             RestartSec = "10s";
+            # SIGTERM drains the in-flight turn; give one long turn room
+            # to finish. Only the daemon gets the signal: its tool
+            # children and MCP servers must outlive it, and systemd
+            # SIGKILLs whatever remains once it exits.
+            TimeoutStopSec = "30min";
+            KillMode = "mixed";
             User = "kitaebot";
             Group = "kitaebot";
             WorkingDirectory = "/var/lib/kitaebot";


### PR DESCRIPTION
Closes #133.

Every daemon stop hard-killed the running turn: `run_with_shutdown` returned out of its `select!` on SIGTERM and took the actor task with it. The actor pattern already exits gracefully once every sender is gone, after finishing the envelope in hand. This PR uses that.

## Commits

1. **Drain the in-flight turn on SIGTERM instead of killing it.** `AgentHandle::spawn` returns the actor's `JoinHandle`; the daemon takes the handle by value, and on shutdown drops the channel loops, calls `begin_drain()`, drops the handle, and awaits the task. A draining actor refuses envelopes already queued in the mailbox with `Err("Agent draining")` (their reply channels are dead, and the channel re-dispatches the event next boot). Sub-agents are awaited inside the turn and finish with it. `MockProvider::gated` holds a turn in flight for the test.
2. **Give the systemd unit room to drain the turn.** `TimeoutStopSec=30min` so systemd does not SIGKILL mid-drain. `KillMode=mixed` so SIGTERM reaches the daemon alone; the default control-group mode would kill the exec tool's children and the MCP servers under the turn being drained.

Specs 01 and 09 and the README updated.

## Verify after deploy

1. Start a long turn (`just ask` or a Telegram message).
2. `systemctl restart kitaebot` in the VM.
3. Journal: `Shutdown signal received.` then `Draining: waiting for the in-flight turn to finish.` then the turn summary, then `Drain complete, exiting.` The reply lands on the channel.

## Note

The first `just check` run hit an unrelated flake: `clients::telegram::tests::network_error_redacts_token_url` bind-and-drops an ephemeral port and asserts "Connection refused", but got "Connection reset by peer" when a parallel test reused the port. Pre-existing; worth its own issue.