### PR TITLE
Re-dispatch reviewer turns a crash interrupted

### DIFF
--- a/specs/20-github.md
+++ b/specs/20-github.md
@@ -544,7 +544,8 @@ replying to stale code.
 The `github_poll` document in the state database (spec 05):
 
 ```json
-{"last_poll": "2026-07-05T12:00:00Z", "reviewed": {"owner/repo#42": "<head-sha>"}}
+{"last_poll": "2026-07-05T12:00:00Z", "reviewed": {"owner/repo#42": "<head-sha>"},
+ "in_flight": {"key": "owner/repo#42", "prev_sha": "<sha-before-dispatch>"}}
 ```
 
 - Missing or corrupt state defaults to `last_poll = now` (avoids
@@ -556,6 +557,18 @@ The `github_poll` document in the state database (spec 05):
   reappearing with the same SHA is skipped — this covers the failure
   loop where the model replies without submitting a formal review, which
   would otherwise re-trigger every tick.
+- `in_flight` names the reviewer turn currently running: its key and
+  the SHA the `reviewed` entry held before dispatch (`null` for a first
+  review). It is written in the same save as the SHA and cleared by a
+  second save when the turn returns, success or failure. A marker still
+  present at channel start means the daemon died mid-turn; the entry is
+  rolled back (removed, or restored to `prev_sha`) so the normal passes
+  re-dispatch — the review request is still pending, or the head still
+  differs from the restored SHA. Only a turn that never returned rolls
+  back; the SHA guard above stands for every turn that did. GitHub
+  cannot tell the two apart (the quiet path publishes nothing on
+  purpose, and so does the model that skips the formal review), which
+  is why this is local state and not a boot-time API reconciliation.
 - A new head SHA on a tracked PR dispatches an incremental re-review
   (see above).
 - Entries are pruned when the PR is closed or merged. Unlike Linear's
@@ -619,6 +632,7 @@ first place. Requires the `github-token` secret.
 | Individual message send fails | Log error, continue with remaining items |
 | Agent turn fails (review) | Logged and alerted via the notifier (spec 17). SHA already recorded, so no retry storm; the next push or a human re-request retries. |
 | Model never submits a formal review | Pending request stays, but the SHA guard prevents re-dispatch. Visible as a stale request on the PR. |
+| Daemon dies mid-review turn | `in_flight` rolls the `reviewed` entry back at next start and the turn re-dispatches. One duplicate review if the kill lands after submission. |
 | Review checkout prep fails (clone/fetch/detach) | Log warning, skip the PR this tick without recording state; retried next tick |
 | Head SHA / tracked-PR fetch fails | Skip the PR this tick |
 | Incremental compare fetch fails | The model falls back to the full diff |

--- a/src/channel/github/prs.rs
+++ b/src/channel/github/prs.rs
@@ -135,6 +135,18 @@ struct PollState {
     /// skipped.
     #[serde(default)]
     reviewed: BTreeMap<String, String>,
+    /// The reviewer turn running right now; survives a crash mid-turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    in_flight: Option<InFlight>,
+}
+
+/// A reviewer turn between its `reviewed` insert and its return.
+#[derive(Debug, Deserialize, serde::Serialize, PartialEq)]
+struct InFlight {
+    /// Tracking key, `owner/repo#42`.
+    key: String,
+    /// SHA the entry held before this dispatch; `None` for a first review.
+    prev_sha: Option<String>,
 }
 
 impl PollState {
@@ -143,6 +155,7 @@ impl PollState {
         Self {
             last_poll: now_iso8601(),
             reviewed: BTreeMap::new(),
+            in_flight: None,
         }
     }
 }
@@ -434,7 +447,11 @@ async fn review_request_pass(
             warn!(pr = %d.key, "Skipping review this tick, checkout prep failed: {e}");
             continue;
         }
-        state.reviewed.insert(d.key, d.head_sha);
+        let prev_sha = state.reviewed.insert(d.key.clone(), d.head_sha);
+        state.in_flight = Some(InFlight {
+            key: d.key,
+            prev_sha,
+        });
         save_state(state_db, state);
         send(
             handle,
@@ -444,6 +461,8 @@ async fn review_request_pass(
             d.message,
         )
         .await;
+        state.in_flight = None;
+        save_state(state_db, state);
         count += 1;
     }
     Ok(count)
@@ -530,7 +549,11 @@ async fn tracked_pass(
             warn!(pr = %d.key, "Skipping tracked turn this tick, checkout prep failed: {e}");
             continue;
         }
-        state.reviewed.insert(d.key, d.head_sha);
+        let prev_sha = state.reviewed.insert(d.key.clone(), d.head_sha);
+        state.in_flight = Some(InFlight {
+            key: d.key,
+            prev_sha,
+        });
         save_state(state_db, state);
         send(
             handle,
@@ -540,6 +563,8 @@ async fn tracked_pass(
             d.message,
         )
         .await;
+        state.in_flight = None;
+        save_state(state_db, state);
         count += 1;
     }
     count
@@ -1471,11 +1496,32 @@ mod tests {
         let state = PollState {
             last_poll: "2025-01-15T10:00:00Z".to_string(),
             reviewed: BTreeMap::from([("owner/repo#42".to_string(), "abc123".to_string())]),
+            in_flight: None,
         };
         save_state(&db, &state);
         let loaded = load_state(&db);
         assert_eq!(loaded.last_poll, "2025-01-15T10:00:00Z");
         assert_eq!(loaded.reviewed, state.reviewed);
+        assert_eq!(loaded.in_flight, None);
+    }
+
+    #[test]
+    fn save_and_load_in_flight_round_trip() {
+        let db = crate::state_db::StateDb::open_in_memory().unwrap();
+
+        for prev_sha in [None, Some("abc123".to_string())] {
+            let state = PollState {
+                last_poll: "2025-01-15T10:00:00Z".to_string(),
+                reviewed: BTreeMap::from([("owner/repo#42".to_string(), "def456".to_string())]),
+                in_flight: Some(InFlight {
+                    key: "owner/repo#42".to_string(),
+                    prev_sha,
+                }),
+            };
+            save_state(&db, &state);
+            let loaded = load_state(&db);
+            assert_eq!(loaded.in_flight, state.in_flight);
+        }
     }
 
     #[test]
@@ -1487,6 +1533,25 @@ mod tests {
         let loaded = load_state(&db);
         assert_eq!(loaded.last_poll, "2025-01-15T10:00:00Z");
         assert!(loaded.reviewed.is_empty());
+    }
+
+    #[test]
+    fn load_state_without_in_flight() {
+        let db = crate::state_db::StateDb::open_in_memory().unwrap();
+        db.put_doc(
+            "github_poll",
+            r#"{"last_poll":"2025-01-15T10:00:00Z","reviewed":{"owner/repo#42":"abc123"}}"#,
+        )
+        .unwrap();
+
+        let loaded = load_state(&db);
+        assert_eq!(loaded.reviewed.len(), 1);
+        assert_eq!(loaded.in_flight, None);
+    }
+
+    #[test]
+    fn starting_now_has_no_in_flight() {
+        assert_eq!(PollState::starting_now().in_flight, None);
     }
 
     #[test]

--- a/src/channel/github/prs.rs
+++ b/src/channel/github/prs.rs
@@ -158,6 +158,17 @@ impl PollState {
             in_flight: None,
         }
     }
+
+    /// Undo the `reviewed` insert of a turn that never returned, so the
+    /// normal passes dispatch it again.
+    fn roll_back_in_flight(&mut self) -> Option<InFlight> {
+        let turn = self.in_flight.take()?;
+        match &turn.prev_sha {
+            None => self.reviewed.remove(&turn.key),
+            Some(sha) => self.reviewed.insert(turn.key.clone(), sha.clone()),
+        };
+        Some(turn)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -187,6 +198,10 @@ pub async fn poll_loop(
     };
 
     let mut state = load_state(state_db);
+    if let Some(turn) = state.roll_back_in_flight() {
+        warn!(pr = %turn.key, "Rolling back reviewer turn interrupted by shutdown");
+        save_state(state_db, &state);
+    }
     info!(last_poll = %state.last_poll, "GitHub channel starting");
 
     let mut tick = time::interval(Duration::from_secs(config.poll_interval_secs));
@@ -1552,6 +1567,52 @@ mod tests {
     #[test]
     fn starting_now_has_no_in_flight() {
         assert_eq!(PollState::starting_now().in_flight, None);
+    }
+
+    fn in_flight_state(prev_sha: Option<&str>) -> PollState {
+        PollState {
+            last_poll: "2025-01-15T10:00:00Z".to_string(),
+            reviewed: BTreeMap::from([("o/r#1".to_string(), "new".to_string())]),
+            in_flight: Some(InFlight {
+                key: "o/r#1".to_string(),
+                prev_sha: prev_sha.map(str::to_string),
+            }),
+        }
+    }
+
+    #[test]
+    fn roll_back_first_review_forgets_the_key() {
+        let mut state = in_flight_state(None);
+        let turn = state.roll_back_in_flight();
+        assert_eq!(turn.map(|t| t.key), Some("o/r#1".to_string()));
+        assert!(state.reviewed.is_empty());
+        assert_eq!(state.in_flight, None);
+    }
+
+    #[test]
+    fn roll_back_re_review_restores_prev_sha() {
+        let mut state = in_flight_state(Some("old"));
+        assert!(state.roll_back_in_flight().is_some());
+        assert_eq!(state.reviewed, reviewed("o/r#1", "old"));
+        assert_eq!(state.in_flight, None);
+    }
+
+    #[test]
+    fn roll_back_comment_only_turn_keeps_sha() {
+        let mut state = in_flight_state(Some("new"));
+        assert!(state.roll_back_in_flight().is_some());
+        assert_eq!(state.reviewed, reviewed("o/r#1", "new"));
+    }
+
+    #[test]
+    fn roll_back_without_in_flight_is_noop() {
+        let mut state = PollState {
+            last_poll: "2025-01-15T10:00:00Z".to_string(),
+            reviewed: reviewed("o/r#1", "abc"),
+            in_flight: None,
+        };
+        assert_eq!(state.roll_back_in_flight(), None);
+        assert_eq!(state.reviewed, reviewed("o/r#1", "abc"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #134.

Both reviewer passes record the head SHA in `reviewed` before the turn runs, so a turn that finishes without a formal review does not re-trigger every tick. The same record swallows a turn the daemon never finished: kill mid-review, SHA stays marked, nothing posted, and the only recovery was amending the head (PR #115).

This does not do the boot-time API reconciliation the issue proposed. GitHub cannot tell a killed turn from the quiet path (publishes nothing on purpose) or from a model that replied without a formal review; an API check would re-dispatch both at every start and defeat the fence. Whether `send()` returned is local state, so that is what gets recorded.

Two commits:

1. `PollState.in_flight` holds the key and the SHA the entry had before dispatch. Written in the same save as the insert, cleared by a second save when the turn returns (Ok or Err). Old state docs deserialize unchanged.
2. At channel start a surviving marker rolls the entry back: key removed for a first review, previous SHA restored for a re-review. Pass 2 or pass 3 then re-dispatches with no new logic. Spec 20 updated (state doc, rollback rule, failure table).

Accepted residue: a kill after the review was submitted but before the second save yields one duplicate review, same class as the corrupt-state case spec 20 already accepts.

Manual check: request a review on a test PR, `kill -9` the daemon while the reviewer turn runs, restart. Expect `Rolling back reviewer turn interrupted by shutdown` in the log and a fresh review dispatch on the next tick.
