### PR TITLE
Inject corrective hints when a failure shape repeats

### DIFF
--- a/specs/01-agent-loop.md
+++ b/specs/01-agent-loop.md
@@ -214,7 +214,8 @@ tool results are `<tool_output>`-framed and the LCM framing parsers
 require the closing tag last, so appending to the result body would
 break payload normalization. Hints are advisory only; they feed no
 strike counter. The `RepeatDetector` still owns literal-identical
-call sets (three identical rounds skip execution); the rerun hint
+call sets (the third consecutive identical round onward is skipped,
+`REPEAT_LIMIT`); the rerun hint
 fires earlier and on a looser match — same test command, other calls
 allowed in between — where the detector correctly stays silent.
 

--- a/specs/01-agent-loop.md
+++ b/specs/01-agent-loop.md
@@ -192,6 +192,32 @@ directive explicitly says to continue with tool calls: under
 turn summary logs `checkpointed` so effectiveness is measurable
 against `max_iterations` outcomes.
 
+### Corrective Hints
+
+The midpoint checkpoint's principle at finer grain: standing prompt
+guidance does not reach a model mid-habit (developer-workflow.md
+described the grep/sed pathology verbatim and failed to prevent it in
+the #136 turns), so the instruction arrives when its trigger fires.
+Three recognized failure shapes each yield one system-notice line per
+turn, appended after the round's tool results:
+
+| Trigger | Hint |
+|---------|------|
+| Failed assertion in tool output | Derive the expected value by hand; the expectation may be the bug. |
+| Identical test command with no `file_edit`/`file_write` since | The result will not change; edit first. |
+| Second `file_edit` no-match on one file | Your view of the file is stale; re-read the region. |
+
+Test commands are recognized by substring across ecosystems (cargo,
+just, pytest, pnpm/npm, go, vitest): the bot works non-Rust repos.
+The hints ride a separate system message rather than the result text:
+tool results are `<tool_output>`-framed and the LCM framing parsers
+require the closing tag last, so appending to the result body would
+break payload normalization. Hints are advisory only; they feed no
+strike counter. The `RepeatDetector` still owns literal-identical
+call sets (three identical rounds skip execution); the rerun hint
+fires earlier and on a looser match — same test command, other calls
+allowed in between — where the detector correctly stays silent.
+
 ### Budget Exhaustion
 
 Hitting `agent.max_iterations` emits `Activity::MaxIterations`, then

--- a/src/agent/hints.rs
+++ b/src/agent/hints.rs
@@ -1,0 +1,205 @@
+//! Event-triggered corrective hints (spec 01).
+//!
+//! Standing prompt guidance does not reach a model mid-habit; the
+//! instruction has to arrive when its trigger fires. Each recognized
+//! failure shape yields one system-notice line, at most once per turn.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// A failed assertion in tool output.
+pub const ASSERT_HINT: &str = "Hint: a test assertion failed. Derive the \
+    expected value by hand from the inputs before changing code: the \
+    test's own expectation may be the bug.";
+
+/// The same test command re-run with no file edit in between.
+pub const RERUN_HINT: &str = "Hint: that test command already ran and no \
+    file_edit or file_write has happened since; the result will not \
+    change. Edit something first or ask a different question.";
+
+/// Repeated `file_edit` no-match on one file.
+pub const STALE_EDIT_HINT: &str = "Hint: file_edit failed to match twice \
+    on that file; your view of it is stale. Re-read the region before \
+    retrying.";
+
+/// Substrings marking a command as a test run. Multi-language on
+/// purpose: the bot works non-Rust repos.
+const TEST_COMMANDS: &[&str] = &[
+    "cargo test",
+    "go test",
+    "just check",
+    "just rust-check",
+    "just test",
+    "npm test",
+    "pnpm test",
+    "pytest",
+    "vitest",
+];
+
+/// The one-shot hint kinds; each fires at most once per turn.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Kind {
+    Assert,
+    Rerun,
+    StaleEdit,
+}
+
+/// Per-turn state for the corrective hints. Purely observational:
+/// callers decide where the returned lines go.
+pub struct HintTracker {
+    fired: BTreeSet<Kind>,
+    /// Last test command seen, and whether a file mutation happened
+    /// after it.
+    last_test: Option<String>,
+    edited_since_test: bool,
+    /// `file_edit` no-match counts per path.
+    no_match: BTreeMap<String, usize>,
+}
+
+impl HintTracker {
+    pub fn new() -> Self {
+        Self {
+            fired: BTreeSet::new(),
+            last_test: None,
+            edited_since_test: true,
+            no_match: BTreeMap::new(),
+        }
+    }
+
+    /// Latch `kind`: the text the first time, `None` after.
+    fn fire(&mut self, kind: Kind, text: &'static str) -> Option<&'static str> {
+        self.fired.insert(kind).then_some(text)
+    }
+
+    /// Observe one completed tool call. Returns a hint the first time
+    /// each failure shape fires in the turn.
+    pub fn observe(
+        &mut self,
+        tool: &str,
+        args: &str,
+        result: Result<&str, &str>,
+    ) -> Option<&'static str> {
+        match tool {
+            "file_edit" | "file_write" => {
+                if result.is_ok() {
+                    self.edited_since_test = true;
+                } else if tool == "file_edit"
+                    && let Err(e) = result
+                    && e.contains("no match found for old_string")
+                {
+                    let path = arg_str(args, "path").unwrap_or_default();
+                    let count = self.no_match.entry(path).or_insert(0);
+                    *count += 1;
+                    if *count >= 2 {
+                        return self.fire(Kind::StaleEdit, STALE_EDIT_HINT);
+                    }
+                }
+            }
+            "exec" => {
+                if let Some(command) = arg_str(args, "command")
+                    && TEST_COMMANDS.iter().any(|t| command.contains(t))
+                {
+                    let rerun = self.last_test.as_deref() == Some(command.as_str())
+                        && !self.edited_since_test;
+                    self.last_test = Some(command);
+                    self.edited_since_test = false;
+                    if rerun {
+                        return self.fire(Kind::Rerun, RERUN_HINT);
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        let text = result.unwrap_or_else(|e| e);
+        if assertion_failed(text) {
+            return self.fire(Kind::Assert, ASSERT_HINT);
+        }
+        None
+    }
+}
+
+/// Failed-assertion shape across libtest vintages and languages.
+fn assertion_failed(text: &str) -> bool {
+    (text.contains("assertion") && text.contains("failed")) || text.contains("panicked at")
+}
+
+/// Extract a string field from a tool-call arguments JSON blob.
+fn arg_str(args: &str, key: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(args).ok()?;
+    value.get(key)?.as_str().map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EDIT_OK: Result<&str, &str> = Ok("edited");
+    const NO_MATCH: Result<&str, &str> = Err(
+        "precondition failed: no match found for old_string in src/a.rs; the file may have changed",
+    );
+
+    fn exec_args(cmd: &str) -> String {
+        serde_json::json!({ "command": cmd }).to_string()
+    }
+
+    #[test]
+    fn assertion_failure_hints_once() {
+        let mut h = HintTracker::new();
+        let out = "thread 'x' panicked at src/a.rs:1:\nassertion `left == right` failed";
+        assert_eq!(
+            h.observe("exec", &exec_args("ls"), Ok(out)),
+            Some(ASSERT_HINT)
+        );
+        assert_eq!(h.observe("exec", &exec_args("ls"), Ok(out)), None);
+    }
+
+    #[test]
+    fn rerun_without_edit_hints_once() {
+        let mut h = HintTracker::new();
+        let args = exec_args("just test-one tools::exec");
+        assert_eq!(h.observe("exec", &args, Ok("test result: ok")), None);
+        assert_eq!(
+            h.observe("exec", &args, Ok("test result: ok")),
+            Some(RERUN_HINT)
+        );
+        assert_eq!(h.observe("exec", &args, Ok("test result: ok")), None);
+    }
+
+    #[test]
+    fn edit_between_runs_suppresses_rerun_hint() {
+        let mut h = HintTracker::new();
+        let args = exec_args("cargo test foo");
+        assert_eq!(h.observe("exec", &args, Ok("ok")), None);
+        assert_eq!(h.observe("file_edit", "{\"path\":\"a.rs\"}", EDIT_OK), None);
+        assert_eq!(h.observe("exec", &args, Ok("ok")), None);
+    }
+
+    #[test]
+    fn different_test_command_is_not_a_rerun() {
+        let mut h = HintTracker::new();
+        assert_eq!(h.observe("exec", &exec_args("pytest a"), Ok("ok")), None);
+        assert_eq!(h.observe("exec", &exec_args("pytest b"), Ok("ok")), None);
+    }
+
+    #[test]
+    fn second_no_match_on_same_file_hints_once() {
+        let mut h = HintTracker::new();
+        let args = "{\"path\":\"src/a.rs\",\"old_string\":\"x\",\"new_string\":\"y\"}";
+        assert_eq!(h.observe("file_edit", args, NO_MATCH), None);
+        assert_eq!(
+            h.observe("file_edit", args, NO_MATCH),
+            Some(STALE_EDIT_HINT)
+        );
+        assert_eq!(h.observe("file_edit", args, NO_MATCH), None);
+    }
+
+    #[test]
+    fn non_test_exec_and_clean_output_hint_nothing() {
+        let mut h = HintTracker::new();
+        assert_eq!(
+            h.observe("exec", &exec_args("git status"), Ok("clean")),
+            None
+        );
+        assert_eq!(h.observe("grep", "{}", Ok("no assertion here")), None);
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -7,6 +7,7 @@
 mod actor;
 pub(crate) mod envelope;
 mod handle;
+mod hints;
 pub(crate) mod task;
 
 pub use handle::AgentHandle;
@@ -511,6 +512,7 @@ async fn turn_loop(
     let tool_definitions: Arc<[ToolDefinition]> = tools.definitions().into();
 
     let mut repeats = RepeatDetector::new();
+    let mut hint_tracker = hints::HintTracker::new();
     let mut policy_strikes: BTreeMap<String, usize> = BTreeMap::new();
     let mut blocked_rounds: usize = 0;
     let mut repeat_strikes: usize = 0;
@@ -681,9 +683,23 @@ async fn turn_loop(
                     })
                     .collect();
 
-                let tool_halt =
-                    record_tool_results(engine, &calls, results, activity_tx, &mut tool_strikes)
-                        .await;
+                let (tool_halt, round_hints) = record_tool_results(
+                    engine,
+                    &calls,
+                    results,
+                    activity_tx,
+                    &mut tool_strikes,
+                    &mut hint_tracker,
+                )
+                .await;
+
+                if !round_hints.is_empty() {
+                    engine
+                        .push_message(Message::System {
+                            content: round_hints.join("\n"),
+                        })
+                        .await?;
+                }
 
                 if let Some(halt) = tool_halt {
                     warn!(
@@ -1080,9 +1096,22 @@ async fn record_tool_results<E: ContextEngine>(
     results: Vec<Result<String, ToolError>>,
     activity_tx: Option<&mpsc::Sender<Activity>>,
     tool_strikes: &mut ToolStrikeTracker,
-) -> Option<TurnOutput> {
+    hint_tracker: &mut hints::HintTracker,
+) -> (Option<TurnOutput>, Vec<&'static str>) {
     let mut halt: Option<TurnOutput> = None;
+    let mut round_hints: Vec<&'static str> = Vec::new();
     for (call, result) in calls.iter().zip(results) {
+        let observed = match &result {
+            Ok(output) => Ok(output.as_str()),
+            Err(e) => Err(e.to_string()),
+        };
+        if let Some(hint) = hint_tracker.observe(
+            call.function.name.as_str(),
+            &call.function.arguments,
+            observed.as_ref().map(|s| *s).map_err(String::as_str),
+        ) {
+            round_hints.push(hint);
+        }
         let (content, err) = match result {
             Ok(output) => {
                 let checked = safety::check_tool_output(call.function.name.as_str(), &output);
@@ -1143,7 +1172,7 @@ async fn record_tool_results<E: ContextEngine>(
             })
             .await;
     }
-    halt
+    (halt, round_hints)
 }
 
 #[cfg(test)]
@@ -1427,6 +1456,47 @@ mod tests {
             })
             .count();
         assert_eq!(directives, 1, "checkpoint must fire exactly once");
+    }
+
+    /// A failed-assertion shape in tool output must surface the
+    /// derive-by-hand hint as a system notice on that round.
+    #[tokio::test]
+    async fn assertion_output_injects_the_corrective_hint_once() {
+        let provider = Arc::new(MockProvider::new(vec![
+            Ok(mock_tool_calls(&["c1"])),
+            Ok(mock_tool_calls(&["c2"])),
+            Ok(text("done")),
+        ]));
+        let tools = mock_tools(
+            "thread 'exec::tests::t' panicked at src/a.rs:9:\n\
+             assertion `left == right` failed\n  left: 1\n right: 2",
+        );
+        let mut engine = test_engine();
+        let summarize = test_summarize(&provider);
+
+        let result = run_turn(
+            &mut engine,
+            &summarize,
+            SYSTEM,
+            "Fix the bug",
+            &*provider,
+            &tools,
+            MAX_ITER,
+            &ToolCtx::default(),
+        )
+        .await;
+
+        assert_eq!(result.unwrap().into_text(), "done");
+        let notices = provider
+            .last_request()
+            .unwrap()
+            .iter()
+            .filter(|m| {
+                matches!(m, Message::System { content }
+                    if content == hints::ASSERT_HINT)
+            })
+            .count();
+        assert_eq!(notices, 1, "hint must fire exactly once per turn");
     }
 
     /// A cap of 1 has midpoint 0; injecting before the first call
@@ -2120,7 +2190,15 @@ mod tests {
 
         let mut engine = test_engine();
         let mut tracker = ToolStrikeTracker::default();
-        record_tool_results(&mut engine, &calls, results, None, &mut tracker).await;
+        record_tool_results(
+            &mut engine,
+            &calls,
+            results,
+            None,
+            &mut tracker,
+            &mut hints::HintTracker::new(),
+        )
+        .await;
 
         let ctx = engine.assemble("").await.unwrap();
         let stored: Vec<&String> = ctx
@@ -2656,9 +2734,16 @@ mod tests {
             };
             let result = exec_failing(&tool, &call, &ctx).await;
             let calls = vec![call];
-            if let Some(h) =
-                record_tool_results(&mut engine, &calls, vec![result], None, &mut tracker).await
-            {
+            let (halted, _) = record_tool_results(
+                &mut engine,
+                &calls,
+                vec![result],
+                None,
+                &mut tracker,
+                &mut hints::HintTracker::new(),
+            )
+            .await;
+            if let Some(h) = halted {
                 halt = Some(h);
                 break;
             }
@@ -2700,7 +2785,15 @@ mod tests {
             };
             let result = exec_failing(&tool, &call, &ctx).await;
             let calls = vec![call];
-            record_tool_results(&mut engine, &calls, vec![result], None, &mut tracker).await;
+            record_tool_results(
+                &mut engine,
+                &calls,
+                vec![result],
+                None,
+                &mut tracker,
+                &mut hints::HintTracker::new(),
+            )
+            .await;
         }
 
         let ctx = engine.assemble("").await.unwrap();
@@ -2744,7 +2837,15 @@ mod tests {
             };
             let result = exec_failing(&tool, &call, &ctx).await;
             let calls = vec![call];
-            record_tool_results(&mut engine, &calls, vec![result], None, &mut tracker).await;
+            record_tool_results(
+                &mut engine,
+                &calls,
+                vec![result],
+                None,
+                &mut tracker,
+                &mut hints::HintTracker::new(),
+            )
+            .await;
         }
 
         let ctx = engine.assemble("").await.unwrap();
@@ -2804,9 +2905,16 @@ mod tests {
             };
             let result = exec_failing(t, &call, &ctx).await;
             let calls = vec![call];
-            if let Some(h) =
-                record_tool_results(&mut engine, &calls, vec![result], None, &mut tracker).await
-            {
+            let (halted, _) = record_tool_results(
+                &mut engine,
+                &calls,
+                vec![result],
+                None,
+                &mut tracker,
+                &mut hints::HintTracker::new(),
+            )
+            .await;
+            if let Some(h) = halted {
                 halt = Some(h);
                 break;
             }
@@ -2842,9 +2950,16 @@ mod tests {
             };
             let result = exec_failing(&tool, &call, &ctx).await;
             let calls = vec![call];
-            if let Some(h) =
-                record_tool_results(&mut engine, &calls, vec![result], None, &mut tracker).await
-            {
+            let (halted, _) = record_tool_results(
+                &mut engine,
+                &calls,
+                vec![result],
+                None,
+                &mut tracker,
+                &mut hints::HintTracker::new(),
+            )
+            .await;
+            if let Some(h) = halted {
                 halt = Some(h);
                 break;
             }


### PR DESCRIPTION
Closes #149.

Standing prompt guidance does not reach a model mid-habit — developer-workflow.md describes the grep/sed pathology verbatim and failed to prevent it in both #136 turns. The checkpoint (cb1fea0) established the pattern that works: the instruction arrives when its trigger fires. This applies it per failure shape.

`HintTracker` (new `src/agent/hints.rs`, pure, unit-tested) observes each completed tool call and yields one line per shape, once per turn:

- failed assertion in output → derive the expected value by hand; the expectation may be the bug
- identical test command with no `file_edit`/`file_write` since → the result will not change
- second `file_edit` no-match on one file → your view is stale; re-read the region

Test commands recognized by substring across cargo/just/pytest/pnpm/npm/go/vitest — non-Rust repos are in scope. Hints ride a separate system message after the round's results, not the result text: results are `<tool_output>`-framed and the LCM framing parsers require the closing tag last. Advisory only, no strike coupling; `RepeatDetector` keeps owning literal-identical call sets, while the rerun hint fires earlier on a looser match where the detector correctly stays silent.

Spec 01 gains a "Corrective Hints" section. Loop-level test proves the assert hint lands exactly once as a system notice; six unit tests cover the tracker.

Manual verification: in a session, run the same `just test-one` twice with no edit between — the second result is followed by the rerun hint system message, and a third run stays silent.
