### PR TITLE
Name a next step in every externalized file stub

### DIFF
--- a/specs/14-context-engine.md
+++ b/specs/14-context-engine.md
@@ -494,14 +494,15 @@ Next: file_read data/output.json with offset/limit windows the original file.
 
 The trailing `Next:` line is content-aware dereference guidance
 (issue #147): models do not follow references through the sanctioned
-tools unprompted — a 200-iteration turn issued zero `lcm_grep` calls
-and re-ran commands instead — so each stub names its own next step.
-Test-runner output (recognized across cargo/pytest/go shapes) points
-at `lcm_grep` over the stored copy and says not to re-run the
-command; an original source path points at windowed `file_read`;
-structured payloads point at the line-oriented stored copy. The
-summarizer's preserve-`<file>`-tags rule carries the line through
-compaction unchanged.
+tools unprompted, so each stub names its own next step. Every target
+is the on-disk copy at `path` — the raw bytes never reach the FTS
+tables (`intercept_large` replaces them before persistence), so
+`lcm_grep` cannot see them. Test-runner output (recognized across
+cargo/pytest/go shapes) points at native `grep` over the stored copy
+and says not to re-run the command; an original source path points
+at windowed `file_read`; structured payloads point at the
+line-oriented stored copy. The summarizer's preserve-`<file>`-tags
+rule carries the line through compaction unchanged.
 
 The `path` attribute comes from an in-band lookup: for an oversized tool
 result, the engine queries the already-persisted `tool_call` part of the

--- a/specs/14-context-engine.md
+++ b/specs/14-context-engine.md
@@ -488,8 +488,20 @@ threshold, it:
 ```
 <file id="file_abc123" path="data/output.json" tokens="142000">
 Exploration summary text here...
+Next: file_read data/output.json with offset/limit windows the original file.
 </file>
 ```
+
+The trailing `Next:` line is content-aware dereference guidance
+(issue #147): models do not follow references through the sanctioned
+tools unprompted — a 200-iteration turn issued zero `lcm_grep` calls
+and re-ran commands instead — so each stub names its own next step.
+Test-runner output (recognized across cargo/pytest/go shapes) points
+at `lcm_grep` over the stored copy and says not to re-run the
+command; an original source path points at windowed `file_read`;
+structured payloads point at the line-oriented stored copy. The
+summarizer's preserve-`<file>`-tags rule carries the line through
+compaction unchanged.
 
 The `path` attribute comes from an in-band lookup: for an oversized tool
 result, the engine queries the already-persisted `tool_call` part of the

--- a/src/context/lcm/engine.rs
+++ b/src/context/lcm/engine.rs
@@ -363,7 +363,6 @@ impl LcmEngine {
             kind,
             explore::looks_like_test_run(&unframed),
             has_source_path,
-            &file_id,
             &path,
         );
         let reference =

--- a/src/context/lcm/engine.rs
+++ b/src/context/lcm/engine.rs
@@ -354,11 +354,20 @@ impl LcmEngine {
         );
         // With no original path, point at the stored payload —
         // workspace-relative, so the confined file tools accept it.
+        let has_source_path = path_hint.is_some();
         let path = path_hint.unwrap_or_else(|| {
             use crate::workspace::{CONTEXT_DIR, LCM_DIR, LCM_PAYLOADS_DIR};
             format!("{CONTEXT_DIR}/{LCM_DIR}/{LCM_PAYLOADS_DIR}/{file_id}")
         });
-        let reference = explore::format_file_reference(&file_id, &path, token_count, &summary);
+        let next_step = explore::next_step(
+            kind,
+            explore::looks_like_test_run(&unframed),
+            has_source_path,
+            &file_id,
+            &path,
+        );
+        let reference =
+            explore::format_file_reference(&file_id, &path, token_count, &summary, &next_step);
         let row = LargeFileRow {
             file_id,
             path,

--- a/src/context/lcm/explore.rs
+++ b/src/context/lcm/explore.rs
@@ -87,17 +87,63 @@ pub fn extract_file_ids(content: &str) -> Vec<String> {
 }
 
 /// Render the `<file>` reference stored in `messages.content` in
-/// place of the raw payload.
+/// place of the raw payload. `next_step` is the content-aware
+/// dereference instruction; empty renders the bare reference.
 pub fn format_file_reference(
     file_id: &str,
     path: &str,
     token_count: usize,
     summary: &str,
+    next_step: &str,
 ) -> String {
-    format!(
-        "<file id=\"{file_id}\" path=\"{path}\" tokens=\"{token_count}\">\n{}\n</file>",
-        summary.trim()
-    )
+    let body = if next_step.is_empty() {
+        summary.trim().to_string()
+    } else {
+        format!("{}\n{next_step}", summary.trim())
+    };
+    format!("<file id=\"{file_id}\" path=\"{path}\" tokens=\"{token_count}\">\n{body}\n</file>")
+}
+
+/// Test-runner output shape, any ecosystem: the payloads a model most
+/// often answers by re-running the command instead of searching.
+pub fn looks_like_test_run(content: &str) -> bool {
+    content.contains("test result:")
+        || content.contains("panicked at")
+        || content.contains("FAILED")
+        || content.contains("=== RUN")
+        || content.contains("passed") && content.contains("failed")
+}
+
+/// The dereference instruction for a `<file>` stub. Models do not
+/// follow references through the sanctioned tools unprompted (a 200
+/// iteration turn issued zero `lcm_grep` calls and re-ran commands
+/// instead), so each stub names its own next step.
+pub fn next_step(
+    kind: FileKind,
+    test_run: bool,
+    has_source_path: bool,
+    file_id: &str,
+    path: &str,
+) -> String {
+    if test_run {
+        return format!(
+            "Next: lcm_grep 'panicked|FAILED|error' {file_id} pulls the \
+             failures from the stored copy; do not re-run the command."
+        );
+    }
+    if has_source_path {
+        return format!("Next: file_read {path} with offset/limit windows the original file.");
+    }
+    match kind {
+        FileKind::Json | FileKind::Xml | FileKind::Yaml => format!(
+            "Next: the stored copy at {path} is line-oriented; lcm_grep a \
+             key ({file_id}) or file_read a range of it."
+        ),
+        _ => format!(
+            "Next: lcm_grep <pattern> {file_id} searches the stored text; \
+             file_read {path} windows it."
+        ),
+    }
 }
 
 /// Reformat a payload for on-disk storage so line-based tools work:
@@ -725,11 +771,63 @@ mod tests {
 
     #[test]
     fn file_reference_includes_attributes() {
-        let r = format_file_reference("file_0123456789abcdef", "data/out.json", 42, "sum");
+        let r = format_file_reference("file_0123456789abcdef", "data/out.json", 42, "sum", "");
         assert_eq!(
             r,
             "<file id=\"file_0123456789abcdef\" path=\"data/out.json\" tokens=\"42\">\nsum\n</file>"
         );
+    }
+
+    #[test]
+    fn file_reference_carries_the_next_step_line() {
+        let r = format_file_reference("file_0123456789abcdef", "src/a.rs", 42, "sum", "Next: x");
+        assert!(r.ends_with("\nsum\nNext: x\n</file>"), "{r}");
+    }
+
+    // ── next-step guidance ──────────────────────────────────────────
+
+    #[test]
+    fn test_run_payload_points_at_lcm_grep_not_rerun() {
+        let step = next_step(
+            FileKind::Text,
+            true,
+            false,
+            "file_ab",
+            "context/lcm/payloads/file_ab",
+        );
+        assert!(step.contains("lcm_grep"), "{step}");
+        assert!(step.contains("do not re-run"), "{step}");
+    }
+
+    #[test]
+    fn source_file_payload_points_at_windowed_file_read() {
+        let step = next_step(FileKind::Code, false, true, "file_ab", "src/tools/exec.rs");
+        assert!(step.contains("file_read src/tools/exec.rs"), "{step}");
+        assert!(step.contains("offset"), "{step}");
+    }
+
+    #[test]
+    fn structured_payload_names_the_stored_copy() {
+        let step = next_step(
+            FileKind::Json,
+            false,
+            false,
+            "file_ab",
+            "context/lcm/payloads/file_ab",
+        );
+        assert!(step.contains("line-oriented"), "{step}");
+        assert!(step.contains("file_ab"), "{step}");
+    }
+
+    #[test]
+    fn test_run_detection_spans_ecosystems() {
+        assert!(looks_like_test_run(
+            "test result: FAILED. 1 passed; 1 failed"
+        ));
+        assert!(looks_like_test_run("thread 'x' panicked at src/a.rs"));
+        assert!(looks_like_test_run("=== RUN   TestFoo"));
+        assert!(looks_like_test_run("2 passed, 1 failed in 0.3s"));
+        assert!(!looks_like_test_run("plain build output, nothing here"));
     }
 
     // ── payload normalization ─────────────────────────────────────

--- a/src/context/lcm/explore.rs
+++ b/src/context/lcm/explore.rs
@@ -109,26 +109,21 @@ pub fn format_file_reference(
 pub fn looks_like_test_run(content: &str) -> bool {
     content.contains("test result:")
         || content.contains("panicked at")
-        || content.contains("FAILED")
         || content.contains("=== RUN")
-        || content.contains("passed") && content.contains("failed")
+        || (content.contains("passed") && content.contains("failed"))
 }
 
 /// The dereference instruction for a `<file>` stub. Models do not
-/// follow references through the sanctioned tools unprompted (a 200
-/// iteration turn issued zero `lcm_grep` calls and re-ran commands
-/// instead), so each stub names its own next step.
-pub fn next_step(
-    kind: FileKind,
-    test_run: bool,
-    has_source_path: bool,
-    file_id: &str,
-    path: &str,
-) -> String {
+/// follow references through the sanctioned tools unprompted, so each
+/// stub names its own next step. The target is the on-disk copy at
+/// `path`: the raw bytes never reach the FTS tables (`intercept_large`
+/// replaces them before persistence), so `lcm_grep` cannot see them.
+pub fn next_step(kind: FileKind, test_run: bool, has_source_path: bool, path: &str) -> String {
     if test_run {
         return format!(
-            "Next: lcm_grep 'panicked|FAILED|error' {file_id} pulls the \
-             failures from the stored copy; do not re-run the command."
+            "Next: grep pattern='panicked at|FAILED|error' path={path} \
+             pulls the failures from the stored copy; do not re-run the \
+             command."
         );
     }
     if has_source_path {
@@ -136,12 +131,12 @@ pub fn next_step(
     }
     match kind {
         FileKind::Json | FileKind::Xml | FileKind::Yaml => format!(
-            "Next: the stored copy at {path} is line-oriented; lcm_grep a \
-             key ({file_id}) or file_read a range of it."
+            "Next: the stored copy at {path} is line-oriented; grep it or \
+             file_read a range of it."
         ),
         _ => format!(
-            "Next: lcm_grep <pattern> {file_id} searches the stored text; \
-             file_read {path} windows it."
+            "Next: grep pattern=<regex> path={path} searches the stored \
+             text; file_read {path} windows it."
         ),
     }
 }
@@ -787,34 +782,24 @@ mod tests {
     // ── next-step guidance ──────────────────────────────────────────
 
     #[test]
-    fn test_run_payload_points_at_lcm_grep_not_rerun() {
-        let step = next_step(
-            FileKind::Text,
-            true,
-            false,
-            "file_ab",
-            "context/lcm/payloads/file_ab",
-        );
-        assert!(step.contains("lcm_grep"), "{step}");
+    fn test_run_payload_points_at_the_stored_copy_not_rerun() {
+        let step = next_step(FileKind::Text, true, false, "context/lcm/payloads/file_ab");
+        assert!(step.contains("grep pattern="), "{step}");
+        assert!(step.contains("path=context/lcm/payloads/file_ab"), "{step}");
         assert!(step.contains("do not re-run"), "{step}");
+        assert!(!step.contains("lcm_grep"), "{step}");
     }
 
     #[test]
     fn source_file_payload_points_at_windowed_file_read() {
-        let step = next_step(FileKind::Code, false, true, "file_ab", "src/tools/exec.rs");
+        let step = next_step(FileKind::Code, false, true, "src/tools/exec.rs");
         assert!(step.contains("file_read src/tools/exec.rs"), "{step}");
         assert!(step.contains("offset"), "{step}");
     }
 
     #[test]
     fn structured_payload_names_the_stored_copy() {
-        let step = next_step(
-            FileKind::Json,
-            false,
-            false,
-            "file_ab",
-            "context/lcm/payloads/file_ab",
-        );
+        let step = next_step(FileKind::Json, false, false, "context/lcm/payloads/file_ab");
         assert!(step.contains("line-oriented"), "{step}");
         assert!(step.contains("file_ab"), "{step}");
     }
@@ -828,6 +813,11 @@ mod tests {
         assert!(looks_like_test_run("=== RUN   TestFoo"));
         assert!(looks_like_test_run("2 passed, 1 failed in 0.3s"));
         assert!(!looks_like_test_run("plain build output, nothing here"));
+        // The word alone is not a test run: source files and logs say
+        // FAILED without being one.
+        assert!(!looks_like_test_run(
+            "const MSG: &str = \"FAILED to connect\";"
+        ));
     }
 
     // ── payload normalization ─────────────────────────────────────


### PR DESCRIPTION
Closes #147.

Models do not dereference `<file>` references through the sanctioned tools unprompted: turn 19 on #136 ran 200 iterations with zero `lcm_grep`/`grep`/`task` calls and re-ran the same test command seven times as its substitute for searching the stored copy. The prose guidance exists in AGENTS.md and demonstrably doesn't transfer mid-habit; the #136 deny-guidance pattern (instruction at the moment of contact) does.

Every stub now ends with a content-aware `Next:` line, chosen by what the payload is:

- test-runner output (cargo/pytest/go shapes) → `lcm_grep 'panicked|FAILED|error' file_xxx`, with an explicit "do not re-run the command"
- payload with an original source path → windowed `file_read <path>`
- structured payloads (JSON/XML/YAML) → the line-oriented stored copy (#119's pretty-printing is why that works)
- everything else → `lcm_grep` the stored text or `file_read` a window

Mechanics: `next_step()` and `looks_like_test_run()` are pure and unit-tested; the engine threads `FileKind`, the source-path flag, and the test-run shape into `format_file_reference`, which appends the line inside the tag body. The summarizer's preserve-`<file>`-tags rule carries it through compaction. An empty next step renders the bare reference, so the compaction/report paths are shape-unchanged. Spec 14's reference example now shows the line.

The mechanical first-panic extract from the issue's fork 2 is deliberately left to #145, which owns capture-time parsing; if that lands, the stub inherits the trailer and this line stays the pointer.

Manual verification: force a small `tool_output_tokens`, exec something producing `test result: FAILED`, and check the stored message's `<file>` stub ends with the lcm_grep instruction.
