### PR TITLE
Append parsed test evidence to failing exec runs

### DIFF
--- a/specs/03-tools.md
+++ b/specs/03-tools.md
@@ -225,6 +225,20 @@ build's last words and the pressure it died under are the diagnosis
 through `cli_runner` (git, warm). Descendants that call `setsid` escape
 the group and the sweep; nothing short of cgroups catches those.
 
+**Test-evidence trailer** (issue #145): exec output recognized as a
+failing test run gets a mechanical trailer appended at dispatch —
+summed pass/fail counts, failed test names (bounded), and the first
+panic block with its assertion values. The model reads results through
+self-authored filters and discards the decisive lines (a 200-iteration
+turn piped seven test runs through `grep -A2 panicked | head -5` while
+debugging a wrong expectation the left/right values would have
+refuted); the trailer preserves the verdict regardless. Recognition is
+a per-format registry — libtest and pytest today — that degrades to no
+trailer on unrecognized output, never to an error, and passing runs get
+none: it exists to preserve failure evidence, not restate green
+summaries. The remaining half of #145, guidance against piping test
+commands at all, waits on the #136 deny-guidance work it builds on.
+
 ---
 
 ### `file_read` — Read File Contents

--- a/src/tools/mock.rs
+++ b/src/tools/mock.rs
@@ -15,12 +15,20 @@ struct Args {}
 
 /// Mock tool that returns configurable output.
 pub struct MockTool {
+    name: &'static str,
     output: String,
 }
 
 impl MockTool {
     pub fn new(output: impl Into<String>) -> Self {
+        Self::named("mock", output)
+    }
+
+    /// A mock registered under another tool's name, for dispatch-path
+    /// behavior keyed on the name (the exec evidence trailer).
+    pub fn named(name: &'static str, output: impl Into<String>) -> Self {
         Self {
+            name,
             output: output.into(),
         }
     }
@@ -28,7 +36,7 @@ impl MockTool {
 
 impl Tool for MockTool {
     fn name(&self) -> &'static str {
-        "mock"
+        self.name
     }
 
     fn description(&self) -> &'static str {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -435,14 +435,18 @@ mod tests {
     use super::*;
     use crate::types::ToolFunction;
 
-    fn mock_call(id: &str) -> ToolCall {
+    fn call_named(name: &str, id: &str) -> ToolCall {
         ToolCall::new(
             id.to_string(),
             ToolFunction {
-                name: "mock".parse().unwrap(),
+                name: name.parse().unwrap(),
                 arguments: "{}".to_string(),
             },
         )
+    }
+
+    fn mock_call(id: &str) -> ToolCall {
+        call_named("mock", id)
     }
 
     #[derive(serde::Deserialize)]
@@ -584,22 +588,12 @@ mod tests {
 
     const FAILING_RUN: &str = "test a ... FAILED\n\ntest result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s\n";
 
-    fn named_call(name: &str) -> ToolCall {
-        ToolCall::new(
-            "c1".to_string(),
-            ToolFunction {
-                name: name.parse().unwrap(),
-                arguments: "{}".to_string(),
-            },
-        )
-    }
-
     /// The dispatch hook (issue #145) fires only for exec results.
     #[tokio::test]
     async fn exec_failing_test_output_gets_the_evidence_trailer() {
         let tools = Tools::new(vec![Arc::new(MockTool::named("exec", FAILING_RUN))], &[]).unwrap();
         let out = tools
-            .execute(&named_call("exec"), ToolCtx::default())
+            .execute(&call_named("exec", "c1"), ToolCtx::default())
             .await
             .unwrap();
         assert!(out.contains("--- parsed test evidence ---"), "{out}");
@@ -611,7 +605,7 @@ mod tests {
     async fn non_exec_tool_output_is_untouched() {
         let tools = Tools::new(vec![Arc::new(MockTool::new(FAILING_RUN))], &[]).unwrap();
         let out = tools
-            .execute(&named_call("mock"), ToolCtx::default())
+            .execute(&call_named("mock", "c1"), ToolCtx::default())
             .await
             .unwrap();
         assert_eq!(out, FAILING_RUN);
@@ -624,7 +618,9 @@ mod tests {
             &[],
         )
         .unwrap();
-        let result = tools.execute(&named_call("exec"), ToolCtx::default()).await;
+        let result = tools
+            .execute(&call_named("exec", "c1"), ToolCtx::default())
+            .await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
     }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -582,6 +582,52 @@ mod tests {
         ));
     }
 
+    const FAILING_RUN: &str = "test a ... FAILED\n\ntest result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s\n";
+
+    fn named_call(name: &str) -> ToolCall {
+        ToolCall::new(
+            "c1".to_string(),
+            ToolFunction {
+                name: name.parse().unwrap(),
+                arguments: "{}".to_string(),
+            },
+        )
+    }
+
+    /// The dispatch hook (issue #145) fires only for exec results.
+    #[tokio::test]
+    async fn exec_failing_test_output_gets_the_evidence_trailer() {
+        let tools = Tools::new(vec![Arc::new(MockTool::named("exec", FAILING_RUN))], &[]).unwrap();
+        let out = tools
+            .execute(&named_call("exec"), ToolCtx::default())
+            .await
+            .unwrap();
+        assert!(out.contains("--- parsed test evidence ---"), "{out}");
+        assert!(out.contains("0 passed, 1 failed"), "{out}");
+        assert!(out.starts_with(FAILING_RUN), "original output must lead");
+    }
+
+    #[tokio::test]
+    async fn non_exec_tool_output_is_untouched() {
+        let tools = Tools::new(vec![Arc::new(MockTool::new(FAILING_RUN))], &[]).unwrap();
+        let out = tools
+            .execute(&named_call("mock"), ToolCtx::default())
+            .await
+            .unwrap();
+        assert_eq!(out, FAILING_RUN);
+    }
+
+    #[tokio::test]
+    async fn exec_errors_pass_through_the_evidence_hook() {
+        let tools = Tools::new(
+            vec![Arc::new(MockBlockedTool::named("exec", "denied"))],
+            &[],
+        )
+        .unwrap();
+        let result = tools.execute(&named_call("exec"), ToolCtx::default()).await;
+        assert!(matches!(result, Err(ToolError::Blocked { .. })));
+    }
+
     #[test]
     fn filtered_projects_allowlist_sharing_instances() {
         let mock: Arc<dyn Tool> = Arc::new(MockTool::new("ok"));

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod mcp;
 mod mock;
 #[cfg(not(feature = "mock-network"))]
 pub(crate) mod network;
+mod test_evidence;
 pub(crate) mod warm;
 
 pub mod path;
@@ -299,7 +300,16 @@ impl Tools {
     pub async fn execute(&self, call: &ToolCall, ctx: ToolCtx) -> Result<String, ToolError> {
         tracing::debug!(tool = %call.function.name, call_id = %call.id, "Tool started");
         let started = std::time::Instant::now();
-        let result = self.dispatch(call, ctx).await;
+        let mut result = self.dispatch(call, ctx).await;
+        // Exec output recognized as a failing test run gets the parsed
+        // verdict appended, surviving whatever the command's own
+        // pipeline filtered away (issue #145).
+        if call.function.name.as_str() == "exec"
+            && let Ok(output) = &result
+            && let Some(trailer) = test_evidence::trailer(output)
+        {
+            result = Ok(format!("{output}\n\n{trailer}"));
+        }
         let elapsed = started.elapsed();
         match &result {
             Ok(output) => tracing::debug!(

--- a/src/tools/test_evidence.rs
+++ b/src/tools/test_evidence.rs
@@ -24,8 +24,9 @@ static LIBTEST_RESULT_RE: LazyLock<Regex> = LazyLock::new(|| {
 static LIBTEST_FAILED_RE: LazyLock<Regex> =
     LazyLock::new(|| crate::text::static_regex(r"(?m)^test (\S+) \.\.\. FAILED$"));
 
-static PYTEST_RESULT_RE: LazyLock<Regex> =
-    LazyLock::new(|| crate::text::static_regex(r"(?m)^=+ .*?(\d+) failed, (\d+) passed.*? =+$"));
+static PYTEST_RESULT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    crate::text::static_regex(r"(?m)^=+ .*?(\d+) failed(?:, (\d+) passed)?.*? =+$")
+});
 
 static PYTEST_FAILED_RE: LazyLock<Regex> =
     LazyLock::new(|| crate::text::static_regex(r"(?m)^FAILED (\S+)"));
@@ -82,12 +83,22 @@ fn libtest(output: &str) -> Option<Evidence> {
     })
 }
 
-/// Pytest short summary: `=== 2 failed, 5 passed in 0.31s ===`.
+/// Pytest short summary, summed across runs. Zero-count categories
+/// are omitted from the line: an all-fail run prints
+/// `=== 3 failed in 0.12s ===` with no passed count at all.
 fn pytest(output: &str) -> Option<Evidence> {
-    let cap = PYTEST_RESULT_RE.captures(output)?;
-    Some(Evidence {
-        passed: cap[2].parse().unwrap_or(0),
-        failed: cap[1].parse().unwrap_or(0),
+    let mut seen = false;
+    let (mut passed, mut failed) = (0u64, 0u64);
+    for cap in PYTEST_RESULT_RE.captures_iter(output) {
+        seen = true;
+        failed += cap[1].parse::<u64>().unwrap_or(0);
+        passed += cap
+            .get(2)
+            .map_or(0, |m| m.as_str().parse::<u64>().unwrap_or(0));
+    }
+    seen.then(|| Evidence {
+        passed,
+        failed,
         failed_names: PYTEST_FAILED_RE
             .captures_iter(output)
             .map(|c| c[1].to_string())
@@ -161,6 +172,25 @@ test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
         let t = trailer(out).unwrap();
         assert!(t.contains("12 passed, 1 failed"), "{t}");
         assert!(t.contains("tests/test_api.py::test_checkout"), "{t}");
+    }
+
+    /// Pytest omits zero-count categories: the all-fail summary has
+    /// no passed count at all, and it is exactly the single-failing
+    /// debugging run the trailer exists for.
+    #[test]
+    fn pytest_all_fail_summary_is_recognized() {
+        let out = "FAILED tests/test_api.py::test_checkout - AssertionError\n\
+                   =========== 3 failed in 0.12s ===========\n";
+        let t = trailer(out).unwrap();
+        assert!(t.contains("0 passed, 3 failed"), "{t}");
+    }
+
+    #[test]
+    fn pytest_counts_sum_across_runs() {
+        let out = "=========== 1 failed, 2 passed in 0.10s ===========\n\
+                   =========== 3 failed in 0.12s ===========\n";
+        let t = trailer(out).unwrap();
+        assert!(t.contains("2 passed, 4 failed"), "{t}");
     }
 
     #[test]

--- a/src/tools/test_evidence.rs
+++ b/src/tools/test_evidence.rs
@@ -1,0 +1,187 @@
+//! Mechanical test-evidence trailer for exec output (issue #145).
+//!
+//! The model reads test results through self-authored filters and
+//! discards the decisive lines; a recognized test run gets a parsed
+//! trailer appended so the verdict survives whatever the pipeline
+//! dropped. Recognition is a per-format registry that degrades to no
+//! trailer on unknown output, never to an error.
+
+use std::fmt::Write as _;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Failed test names listed before the trailer truncates.
+const MAX_FAILED_NAMES: usize = 10;
+
+/// Lines of the first panic block carried into the trailer.
+const PANIC_BLOCK_LINES: usize = 6;
+
+static LIBTEST_RESULT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    crate::text::static_regex(r"(?m)^test result: (ok|FAILED)\. (\d+) passed; (\d+) failed;")
+});
+
+static LIBTEST_FAILED_RE: LazyLock<Regex> =
+    LazyLock::new(|| crate::text::static_regex(r"(?m)^test (\S+) \.\.\. FAILED$"));
+
+static PYTEST_RESULT_RE: LazyLock<Regex> =
+    LazyLock::new(|| crate::text::static_regex(r"(?m)^=+ .*?(\d+) failed, (\d+) passed.*? =+$"));
+
+static PYTEST_FAILED_RE: LazyLock<Regex> =
+    LazyLock::new(|| crate::text::static_regex(r"(?m)^FAILED (\S+)"));
+
+/// Parsed totals and failures from one recognized format.
+struct Evidence {
+    passed: u64,
+    failed: u64,
+    failed_names: Vec<String>,
+}
+
+/// Append-ready trailer for `output`, when it is a recognized test
+/// run with failures. Passing runs and unrecognized formats yield
+/// `None`: the trailer exists to preserve failure evidence, not to
+/// restate a green summary line.
+pub fn trailer(output: &str) -> Option<String> {
+    let evidence = libtest(output).or_else(|| pytest(output))?;
+    if evidence.failed == 0 {
+        return None;
+    }
+    let mut t = format!(
+        "--- parsed test evidence ---\n{} passed, {} failed",
+        evidence.passed, evidence.failed
+    );
+    if !evidence.failed_names.is_empty() {
+        let shown = evidence.failed_names.len().min(MAX_FAILED_NAMES);
+        let _ = write!(t, "\nfailed: {}", evidence.failed_names[..shown].join(", "));
+        if evidence.failed_names.len() > shown {
+            let _ = write!(t, " (+{} more)", evidence.failed_names.len() - shown);
+        }
+    }
+    if let Some(panic) = first_panic(output) {
+        let _ = write!(t, "\nfirst failure:\n{panic}");
+    }
+    Some(t)
+}
+
+/// Sum libtest `test result:` lines across suites.
+fn libtest(output: &str) -> Option<Evidence> {
+    let mut seen = false;
+    let (mut passed, mut failed) = (0u64, 0u64);
+    for cap in LIBTEST_RESULT_RE.captures_iter(output) {
+        seen = true;
+        passed += cap[2].parse::<u64>().unwrap_or(0);
+        failed += cap[3].parse::<u64>().unwrap_or(0);
+    }
+    seen.then(|| Evidence {
+        passed,
+        failed,
+        failed_names: LIBTEST_FAILED_RE
+            .captures_iter(output)
+            .map(|c| c[1].to_string())
+            .collect(),
+    })
+}
+
+/// Pytest short summary: `=== 2 failed, 5 passed in 0.31s ===`.
+fn pytest(output: &str) -> Option<Evidence> {
+    let cap = PYTEST_RESULT_RE.captures(output)?;
+    Some(Evidence {
+        passed: cap[2].parse().unwrap_or(0),
+        failed: cap[1].parse().unwrap_or(0),
+        failed_names: PYTEST_FAILED_RE
+            .captures_iter(output)
+            .map(|c| c[1].to_string())
+            .collect(),
+    })
+}
+
+/// First panic block: the `panicked at` line and the assertion lines
+/// after it, where the left/right values live.
+fn first_panic(output: &str) -> Option<String> {
+    let start = output.find("panicked at")?;
+    let block: Vec<&str> = output
+        .get(start..)?
+        .lines()
+        .take(PANIC_BLOCK_LINES)
+        .take_while(|l| !l.starts_with("note:"))
+        .collect();
+    Some(block.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LIBTEST_FAIL: &str = "\
+running 2 tests
+test tools::exec::tests::a ... ok
+test tools::exec::tests::b ... FAILED
+
+failures:
+
+---- tools::exec::tests::b stdout ----
+
+thread 'tools::exec::tests::b' panicked at src/tools/exec.rs:1869:9:
+assertion `left == right` failed
+  left: Some(\"guidance\")
+ right: None
+note: run with `RUST_BACKTRACE=1` for a backtrace
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+";
+
+    #[test]
+    fn libtest_failure_yields_counts_names_and_values() {
+        let t = trailer(LIBTEST_FAIL).unwrap();
+        assert!(t.contains("1 passed, 1 failed"), "{t}");
+        assert!(t.contains("failed: tools::exec::tests::b"), "{t}");
+        assert!(t.contains("left: Some(\"guidance\")"), "{t}");
+        assert!(t.contains("right: None"), "{t}");
+        assert!(!t.contains("note: run with"), "{t}");
+    }
+
+    #[test]
+    fn passing_run_gets_no_trailer() {
+        let out = "test a ... ok\n\ntest result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s\n";
+        assert_eq!(trailer(out), None);
+    }
+
+    #[test]
+    fn multi_suite_counts_sum() {
+        let out = "test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s\n\
+                   test result: FAILED. 2 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s\n";
+        let t = trailer(out).unwrap();
+        assert!(t.contains("5 passed, 4 failed"), "{t}");
+    }
+
+    #[test]
+    fn pytest_summary_is_recognized() {
+        let out = "FAILED tests/test_api.py::test_checkout - AssertionError\n\
+                   =========== 1 failed, 12 passed in 0.31s ===========\n";
+        let t = trailer(out).unwrap();
+        assert!(t.contains("12 passed, 1 failed"), "{t}");
+        assert!(t.contains("tests/test_api.py::test_checkout"), "{t}");
+    }
+
+    #[test]
+    fn unrecognized_output_yields_nothing() {
+        assert_eq!(
+            trailer("Compiling kitaebot v0.0.1\nerror[E0308]: mismatched types"),
+            None
+        );
+        assert_eq!(trailer(""), None);
+    }
+
+    #[test]
+    fn failed_name_list_truncates() {
+        let names = (0..15).fold(String::new(), |mut s, i| {
+            let _ = writeln!(s, "test m::t{i} ... FAILED");
+            s
+        });
+        let out = format!(
+            "{names}\ntest result: FAILED. 0 passed; 15 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s\n"
+        );
+        let t = trailer(&out).unwrap();
+        assert!(t.contains("(+5 more)"), "{t}");
+    }
+}

--- a/src/tools/test_evidence.rs
+++ b/src/tools/test_evidence.rs
@@ -24,9 +24,11 @@ static LIBTEST_RESULT_RE: LazyLock<Regex> = LazyLock::new(|| {
 static LIBTEST_FAILED_RE: LazyLock<Regex> =
     LazyLock::new(|| crate::text::static_regex(r"(?m)^test (\S+) \.\.\. FAILED$"));
 
-static PYTEST_RESULT_RE: LazyLock<Regex> = LazyLock::new(|| {
-    crate::text::static_regex(r"(?m)^=+ .*?(\d+) failed(?:, (\d+) passed)?.*? =+$")
-});
+static PYTEST_RESULT_RE: LazyLock<Regex> =
+    LazyLock::new(|| crate::text::static_regex(r"(?m)^=+ (.+?) =+$"));
+
+static PYTEST_PAIR_RE: LazyLock<Regex> =
+    LazyLock::new(|| crate::text::static_regex(r"(\d+) ([a-z]+)"));
 
 static PYTEST_FAILED_RE: LazyLock<Regex> =
     LazyLock::new(|| crate::text::static_regex(r"(?m)^FAILED (\S+)"));
@@ -84,17 +86,31 @@ fn libtest(output: &str) -> Option<Evidence> {
 }
 
 /// Pytest short summary, summed across runs. Zero-count categories
-/// are omitted from the line: an all-fail run prints
-/// `=== 3 failed in 0.12s ===` with no passed count at all.
+/// are omitted from the line and their order varies, so every
+/// `N category` pair on a summary bar is scanned: `passed` counts as
+/// passed, `failed`/`error(s)` count as failures (a collection error
+/// is a failure for evidence purposes), and everything else
+/// (skipped, warnings, deselected) is ignored. Bars with no known
+/// category, like the `=== FAILURES ===` section header, do not mark
+/// the output as a pytest run.
 fn pytest(output: &str) -> Option<Evidence> {
     let mut seen = false;
     let (mut passed, mut failed) = (0u64, 0u64);
-    for cap in PYTEST_RESULT_RE.captures_iter(output) {
-        seen = true;
-        failed += cap[1].parse::<u64>().unwrap_or(0);
-        passed += cap
-            .get(2)
-            .map_or(0, |m| m.as_str().parse::<u64>().unwrap_or(0));
+    for line in PYTEST_RESULT_RE.captures_iter(output) {
+        for pair in PYTEST_PAIR_RE.captures_iter(&line[1]) {
+            let count = pair[1].parse::<u64>().unwrap_or(0);
+            match &pair[2] {
+                "passed" => {
+                    seen = true;
+                    passed += count;
+                }
+                "error" | "errors" | "failed" => {
+                    seen = true;
+                    failed += count;
+                }
+                _ => {}
+            }
+        }
     }
     seen.then(|| Evidence {
         passed,
@@ -183,6 +199,27 @@ test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
                    =========== 3 failed in 0.12s ===========\n";
         let t = trailer(out).unwrap();
         assert!(t.contains("0 passed, 3 failed"), "{t}");
+    }
+
+    /// Error-only and mixed-category summaries: a collection error is
+    /// a failure for evidence purposes, warnings and skips are not.
+    #[test]
+    fn pytest_error_categories_count_as_failures() {
+        let t = trailer("=========== 1 error in 0.12s ===========\n").unwrap();
+        assert!(t.contains("0 passed, 1 failed"), "{t}");
+
+        let t = trailer("=========== 1 failed, 1 error, 2 skipped in 0.2s ===========\n").unwrap();
+        assert!(t.contains("0 passed, 2 failed"), "{t}");
+    }
+
+    #[test]
+    fn pytest_warnings_and_headers_are_not_failures() {
+        assert_eq!(
+            trailer("=========== 2 passed, 1 warning in 0.1s ===========\n"),
+            None,
+            "green run with warnings must get no trailer"
+        );
+        assert_eq!(trailer("=========== FAILURES ===========\n"), None);
     }
 
     #[test]


### PR DESCRIPTION
Part of #145: the capture-time trailer. The pipe-discouragement half waits on the #136 deny-guidance branch it builds on.

The model reads test results through self-authored filters and discards the decisive lines: turn 19 on #136 piped seven `just test-one` runs through `grep -A2 panicked | head -5` while debugging a wrong expectation whose left/right values any intact panic would have refuted.

Exec output recognized as a failing test run now gets a mechanical trailer at dispatch: summed pass/fail counts across suites, failed test names (first 10), and the first panic block with its assertion values. Recognition is a per-format registry — libtest and pytest today, sized for the non-Rust repos too — degrading to no trailer on unknown output, never an error. Passing runs get nothing: the trailer preserves failure evidence, not green summaries.

The hook sits in `Tools::execute` dispatch, not exec.rs, deliberately: exec.rs has ~200 uncommitted lines in flight on the #136 branch, and derived-from-output content belongs with the output (inside the eventual `<tool_output>` framing, surviving in the mechanical excerpt's tail if the result externalizes).

Review follow-ups (kitaebot, two passes): pytest recognition generalized to any `N category` summary pairs — zero-count omission, error-only, and mixed shapes covered; counts sum across runs; the `Tools::execute` gate has integration tests via a name-parameterized `MockTool`.

Manual verification: exec a failing `just test-one` unpiped; the result ends with `--- parsed test evidence ---` carrying counts, names, and the left/right values.
